### PR TITLE
[REFACTOR] API 공통 응답 형식을 글로벌 envelope 패턴으로 리팩토링 (#14)

### DIFF
--- a/apps/backend/src/main/java/com/sos/backend/global/common/exception/GlobalExceptionHandler.java
+++ b/apps/backend/src/main/java/com/sos/backend/global/common/exception/GlobalExceptionHandler.java
@@ -6,6 +6,8 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.List;
+
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -15,22 +17,21 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = e.getErrorCode();
         return ResponseEntity
             .status(errorCode.getStatus())
-            .body(ApiResponse.fail(errorCode.getMessage()));
+            .body(ApiResponse.error(errorCode));
     }
 
     // Validation 예외 처리 (@Valid 실패 시)
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse<Void>> handleValidationException(
         MethodArgumentNotValidException e) {
-        String message = e.getBindingResult()
-            .getAllErrors()
+        List<ApiResponse.FieldError> details = e.getBindingResult()
+            .getFieldErrors()
             .stream()
-            .findFirst()
-            .map(error -> error.getDefaultMessage())
-            .orElse(ErrorCode.INVALID_INPUT.getMessage());
+            .map(error -> new ApiResponse.FieldError(error.getField(), error.getDefaultMessage()))
+            .toList();
         return ResponseEntity
             .badRequest()
-            .body(ApiResponse.fail(message));
+            .body(ApiResponse.validationError(details));
     }
 
     // 그 외 모든 예외 처리
@@ -38,6 +39,6 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
         return ResponseEntity
             .internalServerError()
-            .body(ApiResponse.fail(ErrorCode.INTERNAL_SERVER_ERROR.getMessage()));
+            .body(ApiResponse.error(ErrorCode.INTERNAL_SERVER_ERROR));
     }
 }

--- a/apps/backend/src/main/java/com/sos/backend/global/common/response/ApiResponse.java
+++ b/apps/backend/src/main/java/com/sos/backend/global/common/response/ApiResponse.java
@@ -1,27 +1,69 @@
 package com.sos.backend.global.common.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.sos.backend.global.common.exception.ErrorCode;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApiResponse<T> {
 
-    private final String message;
     private final T data;
+    private final ErrorInfo message;
+    private final Meta meta;
 
-    private ApiResponse(String message, T data) {
-        this.message = message;
+    private ApiResponse(T data, ErrorInfo message) {
         this.data = data;
+        this.message = message;
+        this.meta = new Meta(LocalDateTime.now());
     }
 
     public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>("success", data);
+        return new ApiResponse<>(data, null);
     }
 
-    public static <T> ApiResponse<T> success(String message, T data) {
-        return new ApiResponse<>(message, data);
+    public static ApiResponse<Void> error(ErrorCode errorCode) {
+        return new ApiResponse<>(null, new ErrorInfo(errorCode.name(), errorCode.getMessage(), null));
     }
 
-    public static <T> ApiResponse<T> fail(String message) {
-        return new ApiResponse<>(message, null);
+    public static ApiResponse<Void> validationError(List<FieldError> details) {
+        return new ApiResponse<>(null, new ErrorInfo("VALIDATION_ERROR", "입력값이 올바르지 않습니다", details));
+    }
+
+    @Getter
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ErrorInfo {
+        private final String code;
+        private final String message;
+        private final List<FieldError> fieldInfo;
+
+        public ErrorInfo(String code, String message, List<FieldError> details) {
+            this.code = code;
+            this.message = message;
+            this.fieldInfo = details;
+        }
+    }
+
+    @Getter
+    public static class FieldError {
+        private final String field;
+        private final String message;
+
+        public FieldError(String field, String message) {
+            this.field = field;
+            this.message = message;
+        }
+    }
+
+    @Getter
+    public static class Meta {
+        private final LocalDateTime timestamp;
+
+        public Meta(LocalDateTime timestamp) {
+            this.timestamp = timestamp;
+        }
     }
 }

--- a/apps/backend/src/main/java/com/sos/backend/global/common/response/ApiResponse.java
+++ b/apps/backend/src/main/java/com/sos/backend/global/common/response/ApiResponse.java
@@ -12,12 +12,12 @@ import java.util.List;
 public class ApiResponse<T> {
 
     private final T data;
-    private final ErrorInfo message;
+    private final ErrorInfo error;
     private final Meta meta;
 
     private ApiResponse(T data, ErrorInfo message) {
         this.data = data;
-        this.message = message;
+        this.error = message;
         this.meta = new Meta(LocalDateTime.now());
     }
 

--- a/apps/backend/src/main/java/com/sos/backend/global/common/response/ApiResponse.java
+++ b/apps/backend/src/main/java/com/sos/backend/global/common/response/ApiResponse.java
@@ -15,9 +15,9 @@ public class ApiResponse<T> {
     private final ErrorInfo error;
     private final Meta meta;
 
-    private ApiResponse(T data, ErrorInfo message) {
+    private ApiResponse(T data, ErrorInfo error) {
         this.data = data;
-        this.error = message;
+        this.error = error;
         this.meta = new Meta(LocalDateTime.now());
     }
 


### PR DESCRIPTION
## 관련 이슈
Closes #14 

## 작업 내용
기존 ApiResponse가 너무 빈약하여 envelope pattern을 준수하도록 리팩토링
= 성공/에러 응답이 동일한 외형 구조(data + error + meta)를 갖도록 통합

## 변경 사항
- ApiResponse field에 meta 추가
- response를 공통으로 ApiResponse에서 담당하며 success, error, validation error 각각에 맞는 응답을 리턴하도록 함
  (JsonInclude package를 사용하여 null인거는 안 보이게 함으로써 구현)
- 기존에 validation error시 error를 한 개만 가져왔던 문제가 있었는데 ux적으로 좋지 않아서 한 번에 다 가져오도록 수정

## 테스트
api 구현 후 swagger 통해 검증 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선 사항

* **에러 처리 개선**
  * 오류 응답의 포맷이 더 구조화되었습니다.
  * 입력 값 검증 실패 시 각 필드별 상세한 오류 정보가 제공됩니다.
  * 모든 API 응답에 타임스탬프가 포함되어 추적성이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->