### PR TITLE
[FEAT] Add user profile management and onboarding API endpoints

### DIFF
--- a/apps/backend/build.gradle.kts
+++ b/apps/backend/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
 	id("io.spring.dependency-management") version "1.1.7"
 }
 
+val mockitoAgent by configurations.creating
+
 group = "com.sos"
 version = "0.0.1-SNAPSHOT"
 
@@ -38,11 +40,17 @@ dependencies {
     testImplementation("org.testcontainers:junit-jupiter:1.20.4")
     testImplementation("org.testcontainers:postgresql:1.20.4")
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
+	mockitoAgent("org.mockito:mockito-core") {
+		isTransitive = false
+	}
 	testCompileOnly("org.projectlombok:lombok")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 	testAnnotationProcessor("org.projectlombok:lombok")
 }
 
-tasks.withType<Test> {
+tasks.withType<Test>().configureEach {
 	useJUnitPlatform()
+	jvmArgumentProviders += CommandLineArgumentProvider {
+		listOf("-javaagent:${mockitoAgent.singleFile.absolutePath}")
+	}
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/controller/UserController.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/controller/UserController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -29,8 +30,7 @@ public class UserController {
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유저 또는 프로필을 찾을 수 없음",
         content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     public ApiResponse<UserInfoResponse> getMyInfo(
-        @Parameter(description = "임시 사용자 식별자", required = true, example = "1")
-        @RequestHeader("X-User-Id") Long userId
+        @AuthenticationPrincipal Long userId
     ) {
         return ApiResponse.success(userService.getMyInfo(userId));
     }
@@ -43,8 +43,7 @@ public class UserController {
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유저 또는 프로필을 찾을 수 없음",
         content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     public ApiResponse<UserActionResponse> updateMyInfo(
-        @Parameter(description = "임시 사용자 식별자", required = true, example = "1")
-        @RequestHeader("X-User-Id") Long userId,
+        @AuthenticationPrincipal Long userId,
         @Valid @RequestBody UserUpdateRequest request
     ) {
         return ApiResponse.success(userService.updateMyInfo(userId, request));
@@ -58,8 +57,7 @@ public class UserController {
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유저 또는 프로필을 찾을 수 없음",
         content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     public ApiResponse<UserActionResponse> onboard(
-        @Parameter(description = "임시 사용자 식별자", required = true, example = "1")
-        @RequestHeader("X-User-Id") Long userId,
+        @AuthenticationPrincipal Long userId,
         @Valid @RequestBody OnboardingRequest request
     ) {
         return ApiResponse.success(userService.onboard(userId, request));

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/controller/UserController.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/controller/UserController.java
@@ -1,0 +1,67 @@
+package com.sos.backend.domain.user.controller;
+
+import com.sos.backend.domain.user.dto.OnboardingRequest;
+import com.sos.backend.domain.user.dto.UserActionResponse;
+import com.sos.backend.domain.user.dto.UserInfoResponse;
+import com.sos.backend.domain.user.dto.UserUpdateRequest;
+import com.sos.backend.domain.user.service.UserService;
+import com.sos.backend.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users/me")
+@Tag(name = "User", description = "내 정보 조회/수정 및 온보딩 API")
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping
+    @Operation(summary = "내 정보 조회", description = "현재 사용자(임시: X-User-Id)의 기본 정보를 조회합니다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유저 또는 프로필을 찾을 수 없음",
+        content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    public ApiResponse<UserInfoResponse> getMyInfo(
+        @Parameter(description = "임시 사용자 식별자", required = true, example = "1")
+        @RequestHeader("X-User-Id") Long userId
+    ) {
+        return ApiResponse.success(userService.getMyInfo(userId));
+    }
+
+    @PatchMapping
+    @Operation(summary = "내 정보 수정", description = "직업, 성별, 연령대를 수정합니다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 입력값",
+        content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유저 또는 프로필을 찾을 수 없음",
+        content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    public ApiResponse<UserActionResponse> updateMyInfo(
+        @Parameter(description = "임시 사용자 식별자", required = true, example = "1")
+        @RequestHeader("X-User-Id") Long userId,
+        @Valid @RequestBody UserUpdateRequest request
+    ) {
+        return ApiResponse.success(userService.updateMyInfo(userId, request));
+    }
+
+    @PostMapping("/onboarding")
+    @Operation(summary = "온보딩", description = "온보딩 설문을 저장하고 사용자 상태를 ACTIVE로 변경합니다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "온보딩 완료")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 입력값 또는 이미 온보딩 완료된 사용자",
+        content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유저 또는 프로필을 찾을 수 없음",
+        content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    public ApiResponse<UserActionResponse> onboard(
+        @Parameter(description = "임시 사용자 식별자", required = true, example = "1")
+        @RequestHeader("X-User-Id") Long userId,
+        @Valid @RequestBody OnboardingRequest request
+    ) {
+        return ApiResponse.success(userService.onboard(userId, request));
+    }
+}

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/dto/OnboardingRequest.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/dto/OnboardingRequest.java
@@ -1,0 +1,62 @@
+package com.sos.backend.domain.user.dto;
+
+import com.sos.backend.domain.user.enums.*;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+@Schema(description = "온보딩 요청")
+public record OnboardingRequest(
+    @Schema(
+        description = "직업 (고정 값)",
+        example = "EMPLOYEE",
+        allowableValues = {"STUDENT_K12", "UNIV_STUDENT", "JOB_SEEKER", "EMPLOYEE", "SELF_EMPLOYED", "FREELANCER", "HOMEMAKER", "UNEMPLOYED", "OTHER"}
+    )
+    @NotNull(message = "occupation은 필수입니다")
+    Occupation occupation,
+
+    @Schema(description = "성별", example = "MALE")
+    @NotNull(message = "gender는 필수입니다")
+    Gender gender,
+
+    @Schema(
+        description = "연령대",
+        example = "THIRTIES",
+        allowableValues = {"TEENS", "TWENTIES", "THIRTIES", "FORTIES", "FIFTIES", "SIXTIES_AND_ABOVE"}
+    )
+    @NotNull(message = "ageGroup은 필수입니다")
+    AgeGroup ageGroup,
+
+    @ArraySchema(
+        schema = @Schema(implementation = EconomicActivity.class),
+        arraySchema = @Schema(description = "질문1: 소비 활동 (다중선택)", example = "[\"ENTERTAINMENT\",\"TRAVEL\"]")
+    )
+    @NotEmpty(message = "economicActivities는 1개 이상 선택해야 합니다")
+    List<@NotNull EconomicActivity> economicActivities,
+
+    @ArraySchema(
+        schema = @Schema(implementation = CommunicateChannel.class),
+        arraySchema = @Schema(description = "질문2: 주 소통 채널 (다중선택)", example = "[\"PHONE\",\"MESSENGER\"]"))
+    @NotEmpty(message = "communicateChannels는 1개 이상 선택해야 합니다")
+    List<@NotNull CommunicateChannel> communicateChannels,
+
+    @ArraySchema(
+        schema = @Schema(implementation = OnlineActivity.class),
+        arraySchema = @Schema(description = "질문3: 온라인 활동 (다중선택)", example = "[\"ONLINE_SHOPPING\",\"DELIVERY\"]"))
+    @NotEmpty(message = "onlineActivities는 1개 이상 선택해야 합니다")
+    List<@NotNull OnlineActivity> onlineActivities,
+
+    @ArraySchema(
+        schema = @Schema(implementation = FinancialChannel.class),
+        arraySchema = @Schema(description = "질문4: 금융 채널 (다중선택)", example = "[\"MOBILE_BANKING\",\"EASY_PAY\"]"))
+    @NotEmpty(message = "financialChannels는 1개 이상 선택해야 합니다")
+    List<@NotNull FinancialChannel> financialChannels,
+
+    @Schema(description = "질문5: 가족 형태 (단일선택)", example = "WITH_PARENTS")
+    @NotNull(message = "familyType은 필수입니다")
+    FamilyType familyType
+) {
+}

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/dto/UserActionResponse.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/dto/UserActionResponse.java
@@ -1,0 +1,13 @@
+package com.sos.backend.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "수정/온보딩 완료 응답")
+public record UserActionResponse(
+    @Schema(description = "처리 결과 메시지", example = "내 정보가 수정되었습니다.")
+    String message
+) {
+    public static UserActionResponse of(String message) {
+        return new UserActionResponse(message);
+    }
+}

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/dto/UserInfoResponse.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/dto/UserInfoResponse.java
@@ -1,0 +1,36 @@
+package com.sos.backend.domain.user.dto;
+
+import com.sos.backend.domain.user.entity.User;
+import com.sos.backend.domain.user.entity.UserProfile;
+import com.sos.backend.domain.user.enums.AgeGroup;
+import com.sos.backend.domain.user.enums.Gender;
+import com.sos.backend.domain.user.enums.Occupation;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "내 정보 조회 응답")
+public record UserInfoResponse(
+    @Schema(description = "이름", example = "홍길동")
+    String name,
+
+    @Schema(description = "가입 이메일", example = "hong@example.com")
+    String email,
+
+    @Schema(description = "직업", example = "EMPLOYEE")
+    Occupation occupation,
+
+    @Schema(description = "성별", example = "MALE")
+    Gender gender,
+
+    @Schema(description = "연령대", example = "TWENTIES")
+    AgeGroup ageGroup
+) {
+    public static UserInfoResponse from(User user, UserProfile profile) {
+        return new UserInfoResponse(
+            user.getName(),
+            user.getEmail(),
+            profile.getOccupation(),
+            profile.getGender(),
+            profile.getAgeGroup()
+        );
+    }
+}

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/dto/UserUpdateRequest.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/dto/UserUpdateRequest.java
@@ -1,0 +1,27 @@
+package com.sos.backend.domain.user.dto;
+
+import com.sos.backend.domain.user.enums.AgeGroup;
+import com.sos.backend.domain.user.enums.Gender;
+import com.sos.backend.domain.user.enums.Occupation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "내 정보 수정 요청")
+public record UserUpdateRequest(
+    @Schema(
+        description = "직업 (고정 값)",
+        example = "UNIV_STUDENT",
+        allowableValues = {"STUDENT_K12", "UNIV_STUDENT", "JOB_SEEKER", "EMPLOYEE", "SELF_EMPLOYED", "FREELANCER", "HOMEMAKER", "UNEMPLOYED", "OTHER"}
+    )
+    @NotNull(message = "occupation은 필수입니다")
+    Occupation occupation,
+
+    @Schema(description = "성별", example = "FEMALE")
+    @NotNull(message = "gender는 필수입니다")
+    Gender gender,
+
+    @Schema(description = "연령대", example = "TEENS")
+    @NotNull(message = "ageGroup은 필수입니다")
+    AgeGroup ageGroup
+) {
+}

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/entity/User.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/entity/User.java
@@ -48,4 +48,8 @@ public class User extends BaseEntity {
 
     @Column(name = "last_login_at")
     private LocalDateTime lastLoginAt;
+
+    public void changeStatus(UserStatus status) {
+        this.status = status;
+    }
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/entity/UserProfile.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/entity/UserProfile.java
@@ -1,6 +1,8 @@
 package com.sos.backend.domain.user.entity;
 
 import com.sos.backend.domain.user.enums.Gender;
+import com.sos.backend.domain.user.enums.AgeGroup;
+import com.sos.backend.domain.user.enums.Occupation;
 import com.sos.backend.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -18,16 +20,17 @@ import java.util.List;
 public class UserProfile extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "profile_id")
-    private Long profileId;
+    @Column(name = "user_id")
+    private Long userId;
 
+    @MapsId
     @OneToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(name = "occupation", length = 50)
-    private String occupation;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "occupation", length = 30)
+    private Occupation occupation;
 
     @Column(name = "birth")
     private Integer birth;
@@ -35,6 +38,10 @@ public class UserProfile extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "gender", length = 10)
     private Gender gender;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "age_group", length = 30)
+    private AgeGroup ageGroup;
 
     @Column(name = "onboarding_completed", nullable = false)
     private Boolean onboardingCompleted;
@@ -60,4 +67,31 @@ public class UserProfile extends BaseEntity {
     @JdbcTypeCode(SqlTypes.ARRAY)
     @Column(name = "family_type", columnDefinition = "text[]")
     private List<String> familyType;
+
+    public void updateBasicInfo(Occupation occupation, Gender gender, AgeGroup ageGroup) {
+        this.occupation = occupation;
+        this.gender = gender;
+        this.ageGroup = ageGroup;
+    }
+
+    public void completeOnboarding(
+        Occupation occupation,
+        Gender gender,
+        AgeGroup ageGroup,
+        List<String> economicActivities,
+        List<String> communicateChannels,
+        List<String> onlineActivities,
+        List<String> financialChannels,
+        List<String> familyType
+    ) {
+        this.occupation = occupation;
+        this.gender = gender;
+        this.ageGroup = ageGroup;
+        this.economicActivities = economicActivities;
+        this.communicateChannels = communicateChannels;
+        this.onlineActivities = onlineActivities;
+        this.financialChannels = financialChannels;
+        this.familyType = familyType;
+        this.onboardingCompleted = true;
+    }
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/enums/AgeGroup.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/enums/AgeGroup.java
@@ -1,0 +1,10 @@
+package com.sos.backend.domain.user.enums;
+
+public enum AgeGroup {
+    TEENS,
+    TWENTIES,
+    THIRTIES,
+    FORTIES,
+    FIFTIES,
+    SIXTIES_AND_ABOVE
+}

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/enums/EconomicActivity.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/enums/EconomicActivity.java
@@ -3,14 +3,12 @@ package com.sos.backend.domain.user.enums;
 import java.util.Arrays;
 
 public enum EconomicActivity {
-    EMPLOYEE("employee"),
-    SELF_EMPLOYED("self_employed"),
-    SIDE_JOB("side_job"),
-    INVESTMENT("investment"),
+    ENTERTAINMENT("entertainment"),
+    TRAVEL("travel"),
+    SUBSCRIPTION("subscription"),
+    EDUCATION("education"),
     ONLINE_SHOPPING("online_shopping"),
-    JOB_SEEKING("job_seeking"),
-    STUDENT("student"),
-    NONE("none");
+    INVESTMENT("investment");
 
     private final String code;
 

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/enums/Occupation.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/enums/Occupation.java
@@ -1,0 +1,13 @@
+package com.sos.backend.domain.user.enums;
+
+public enum Occupation {
+    STUDENT_K12,
+    UNIV_STUDENT,
+    JOB_SEEKER,
+    EMPLOYEE,
+    SELF_EMPLOYED,
+    FREELANCER,
+    HOMEMAKER,
+    UNEMPLOYED,
+    OTHER
+}

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/enums/UserStatus.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/enums/UserStatus.java
@@ -1,5 +1,5 @@
 package com.sos.backend.domain.user.enums;
 
 public enum UserStatus {
-    ACTIVE, INACTIVE, WITHDRAWN
+    ACTIVE, INACTIVE, ONBOARDING, WITHDRAWN
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/repository/UserProfileRepository.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/repository/UserProfileRepository.java
@@ -3,4 +3,9 @@ package com.sos.backend.domain.user.repository;
 import com.sos.backend.domain.user.entity.UserProfile;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserProfileRepository extends JpaRepository<UserProfile, Long> { }
+import java.util.Optional;
+
+public interface UserProfileRepository extends JpaRepository<UserProfile, Long> {
+
+    Optional<UserProfile> findByUserId(Long userId);
+}

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/service/UserService.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/service/UserService.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -49,7 +50,7 @@ public class UserService {
         User user = getUser(userId);
         UserProfile profile = getUserProfile(userId);
 
-        if (user.getStatus() == UserStatus.ACTIVE) {
+        if (!Set.of(UserStatus.ONBOARDING, UserStatus.INACTIVE).contains(user.getStatus())) {
             throw new CustomException(ErrorCode.INVALID_INPUT);
         }
 

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/service/UserService.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/service/UserService.java
@@ -1,0 +1,80 @@
+package com.sos.backend.domain.user.service;
+
+import com.sos.backend.domain.user.dto.OnboardingRequest;
+import com.sos.backend.domain.user.dto.UserActionResponse;
+import com.sos.backend.domain.user.dto.UserInfoResponse;
+import com.sos.backend.domain.user.dto.UserUpdateRequest;
+import com.sos.backend.domain.user.entity.User;
+import com.sos.backend.domain.user.entity.UserProfile;
+import com.sos.backend.domain.user.enums.CommunicateChannel;
+import com.sos.backend.domain.user.enums.EconomicActivity;
+import com.sos.backend.domain.user.enums.FinancialChannel;
+import com.sos.backend.domain.user.enums.OnlineActivity;
+import com.sos.backend.domain.user.enums.UserStatus;
+import com.sos.backend.domain.user.repository.UserProfileRepository;
+import com.sos.backend.domain.user.repository.UserRepository;
+import com.sos.backend.global.common.exception.CustomException;
+import com.sos.backend.global.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final UserProfileRepository userProfileRepository;
+
+    public UserInfoResponse getMyInfo(Long userId) {
+        User user = getUser(userId);
+        UserProfile profile = getUserProfile(userId);
+        return UserInfoResponse.from(user, profile);
+    }
+
+    @Transactional
+    public UserActionResponse updateMyInfo(Long userId, UserUpdateRequest request) {
+        getUser(userId);
+        UserProfile profile = getUserProfile(userId);
+
+        profile.updateBasicInfo(request.occupation(), request.gender(), request.ageGroup());
+        return UserActionResponse.of("내 정보가 수정되었습니다.");
+    }
+
+    @Transactional
+    public UserActionResponse onboard(Long userId, OnboardingRequest request) {
+        User user = getUser(userId);
+        UserProfile profile = getUserProfile(userId);
+
+        if (user.getStatus() == UserStatus.ACTIVE) {
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+
+        profile.completeOnboarding(
+            request.occupation(),
+            request.gender(),
+            request.ageGroup(),
+            request.economicActivities().stream().map(EconomicActivity::code).toList(),
+            request.communicateChannels().stream().map(CommunicateChannel::code).toList(),
+            request.onlineActivities().stream().map(OnlineActivity::code).toList(),
+            request.financialChannels().stream().map(FinancialChannel::code).toList(),
+            List.of(request.familyType().code())
+        );
+        user.changeStatus(UserStatus.ACTIVE);
+
+        return UserActionResponse.of("온보딩이 완료되었습니다.");
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private UserProfile getUserProfile(Long userId) {
+        return userProfileRepository.findByUserId(userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+    }
+}

--- a/apps/backend/src/main/resources/application-local.yml
+++ b/apps/backend/src/main/resources/application-local.yml
@@ -1,7 +1,7 @@
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/${POSTGRES_DB}
-    username: ${POSTGRES_USER}
+    url: jdbc:postgresql://localhost:5432/${POSTGRES_DB:sos_db}
+    username: ${POSTGRES_USER:sos_user}
     password: ${POSTGRES_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
@@ -12,7 +12,6 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        dialect: org.hibernate.dialect.PostgreSQLDialect
 
   mail:
     host: localhost

--- a/apps/backend/src/test/java/com/sos/backend/domain/user/enums/EconomicActivityTest.java
+++ b/apps/backend/src/test/java/com/sos/backend/domain/user/enums/EconomicActivityTest.java
@@ -1,0 +1,28 @@
+package com.sos.backend.domain.user.enums;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class EconomicActivityTest {
+
+    @Test
+    @DisplayName("현재 코드값은 정상 역매핑된다")
+    void fromCode_currentValues() {
+        assertThat(EconomicActivity.fromCode("entertainment")).isEqualTo(EconomicActivity.ENTERTAINMENT);
+        assertThat(EconomicActivity.fromCode("travel")).isEqualTo(EconomicActivity.TRAVEL);
+        assertThat(EconomicActivity.fromCode("subscription")).isEqualTo(EconomicActivity.SUBSCRIPTION);
+        assertThat(EconomicActivity.fromCode("education")).isEqualTo(EconomicActivity.EDUCATION);
+        assertThat(EconomicActivity.fromCode("online_shopping")).isEqualTo(EconomicActivity.ONLINE_SHOPPING);
+        assertThat(EconomicActivity.fromCode("investment")).isEqualTo(EconomicActivity.INVESTMENT);
+    }
+
+    @Test
+    @DisplayName("알 수 없는 값은 예외를 던진다")
+    void fromCode_invalid() {
+        assertThatThrownBy(() -> EconomicActivity.fromCode("invalid_code"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/apps/backend/src/test/java/com/sos/backend/domain/user/service/UserServiceTest.java
+++ b/apps/backend/src/test/java/com/sos/backend/domain/user/service/UserServiceTest.java
@@ -128,6 +128,23 @@ class UserServiceTest {
         }
 
         @Test
+        @DisplayName("WITHDRAWN 상태면 INVALID_INPUT 예외를 던진다")
+        void onboard_withdrawnUser() {
+            Long userId = 1L;
+            User user = createUser(userId, UserStatus.WITHDRAWN);
+            UserProfile profile = createProfile(userId, user);
+            OnboardingRequest request = createOnboardingRequest();
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+            given(userProfileRepository.findByUserId(userId)).willReturn(Optional.of(profile));
+
+            assertThatThrownBy(() -> userService.onboard(userId, request))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_INPUT);
+        }
+
+        @Test
         @DisplayName("온보딩 완료 시 프로필 저장값을 반영하고 UserStatus를 ACTIVE로 변경한다")
         void onboard_success() {
             Long userId = 1L;

--- a/apps/backend/src/test/java/com/sos/backend/domain/user/service/UserServiceTest.java
+++ b/apps/backend/src/test/java/com/sos/backend/domain/user/service/UserServiceTest.java
@@ -1,0 +1,209 @@
+package com.sos.backend.domain.user.service;
+
+import com.sos.backend.domain.user.dto.OnboardingRequest;
+import com.sos.backend.domain.user.dto.UserActionResponse;
+import com.sos.backend.domain.user.dto.UserInfoResponse;
+import com.sos.backend.domain.user.dto.UserUpdateRequest;
+import com.sos.backend.domain.user.entity.User;
+import com.sos.backend.domain.user.entity.UserProfile;
+import com.sos.backend.domain.user.enums.*;
+import com.sos.backend.domain.user.repository.UserProfileRepository;
+import com.sos.backend.domain.user.repository.UserRepository;
+import com.sos.backend.global.common.exception.CustomException;
+import com.sos.backend.global.common.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserProfileRepository userProfileRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Nested
+    @DisplayName("내 정보 조회")
+    class GetMyInfo {
+
+        @Test
+        @DisplayName("유저와 프로필이 존재하면 기본 정보를 반환한다")
+        void getMyInfo_success() {
+            Long userId = 1L;
+            User user = createUser(userId, UserStatus.ONBOARDING);
+            UserProfile profile = createProfile(userId, user);
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+            given(userProfileRepository.findByUserId(userId)).willReturn(Optional.of(profile));
+
+            UserInfoResponse response = userService.getMyInfo(userId);
+
+            assertThat(response.name()).isEqualTo("홍길동");
+            assertThat(response.email()).isEqualTo("hong@example.com");
+            assertThat(response.occupation()).isEqualTo(Occupation.EMPLOYEE);
+            assertThat(response.gender()).isEqualTo(Gender.MALE);
+            assertThat(response.ageGroup()).isEqualTo(AgeGroup.TWENTIES);
+        }
+
+        @Test
+        @DisplayName("유저가 없으면 USER_NOT_FOUND 예외를 던진다")
+        void getMyInfo_userNotFound() {
+            Long userId = 999L;
+            given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> userService.getMyInfo(userId))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.USER_NOT_FOUND);
+
+            verify(userProfileRepository, never()).findByUserId(userId);
+        }
+    }
+
+    @Nested
+    @DisplayName("내 정보 수정")
+    class UpdateMyInfo {
+
+        @Test
+        @DisplayName("직업/성별/연령대를 수정한다")
+        void updateMyInfo_success() {
+            Long userId = 1L;
+            User user = createUser(userId, UserStatus.ONBOARDING);
+            UserProfile profile = createProfile(userId, user);
+            UserUpdateRequest request = new UserUpdateRequest(
+                Occupation.FREELANCER,
+                Gender.FEMALE,
+                AgeGroup.THIRTIES
+            );
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+            given(userProfileRepository.findByUserId(userId)).willReturn(Optional.of(profile));
+
+            UserActionResponse response = userService.updateMyInfo(userId, request);
+
+            assertThat(response.message()).isEqualTo("내 정보가 수정되었습니다.");
+            assertThat(profile.getOccupation()).isEqualTo(Occupation.FREELANCER);
+            assertThat(profile.getGender()).isEqualTo(Gender.FEMALE);
+            assertThat(profile.getAgeGroup()).isEqualTo(AgeGroup.THIRTIES);
+        }
+    }
+
+    @Nested
+    @DisplayName("온보딩")
+    class Onboard {
+
+        @Test
+        @DisplayName("이미 ACTIVE 상태면 INVALID_INPUT 예외를 던진다")
+        void onboard_alreadyActive() {
+            Long userId = 1L;
+            User user = createUser(userId, UserStatus.ACTIVE);
+            UserProfile profile = createProfile(userId, user);
+            OnboardingRequest request = createOnboardingRequest();
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+            given(userProfileRepository.findByUserId(userId)).willReturn(Optional.of(profile));
+
+            assertThatThrownBy(() -> userService.onboard(userId, request))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_INPUT);
+        }
+
+        @Test
+        @DisplayName("온보딩 완료 시 프로필 저장값을 반영하고 UserStatus를 ACTIVE로 변경한다")
+        void onboard_success() {
+            Long userId = 1L;
+            User user = createUser(userId, UserStatus.ONBOARDING);
+            UserProfile profile = createProfile(userId, user);
+            OnboardingRequest request = createOnboardingRequest();
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+            given(userProfileRepository.findByUserId(userId)).willReturn(Optional.of(profile));
+
+            UserActionResponse response = userService.onboard(userId, request);
+
+            assertThat(response.message()).isEqualTo("온보딩이 완료되었습니다.");
+            assertThat(user.getStatus()).isEqualTo(UserStatus.ACTIVE);
+            assertThat(profile.getOnboardingCompleted()).isTrue();
+            assertThat(profile.getOccupation()).isEqualTo(Occupation.EMPLOYEE);
+            assertThat(profile.getEconomicActivities()).containsExactly("entertainment", "travel");
+            assertThat(profile.getCommunicateChannels()).containsExactly("phone", "email");
+            assertThat(profile.getOnlineActivities()).containsExactly("delivery", "government");
+            assertThat(profile.getFinancialChannels()).containsExactly("mobile_banking", "easy_pay");
+            assertThat(profile.getFamilyType()).containsExactly("with_parents");
+        }
+
+        @Test
+        @DisplayName("프로필이 없으면 NOT_FOUND 예외를 던진다")
+        void onboard_profileNotFound() {
+            Long userId = 1L;
+            User user = createUser(userId, UserStatus.ONBOARDING);
+            OnboardingRequest request = createOnboardingRequest();
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+            given(userProfileRepository.findByUserId(userId)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> userService.onboard(userId, request))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.NOT_FOUND);
+        }
+    }
+
+    private User createUser(Long id, UserStatus status) {
+        return User.builder()
+            .id(id)
+            .email("hong@example.com")
+            .name("홍길동")
+            .role(Role.USER)
+            .status(status)
+            .build();
+    }
+
+    private UserProfile createProfile(Long userId, User user) {
+        return UserProfile.builder()
+            .userId(userId)
+            .user(user)
+            .occupation(Occupation.EMPLOYEE)
+            .gender(Gender.MALE)
+            .ageGroup(AgeGroup.TWENTIES)
+            .onboardingCompleted(false)
+            .economicActivities(List.of())
+            .communicateChannels(List.of())
+            .onlineActivities(List.of())
+            .financialChannels(List.of())
+            .familyType(List.of())
+            .build();
+    }
+
+    private OnboardingRequest createOnboardingRequest() {
+        return new OnboardingRequest(
+            Occupation.EMPLOYEE,
+            Gender.MALE,
+            AgeGroup.TWENTIES,
+            List.of(EconomicActivity.ENTERTAINMENT, EconomicActivity.TRAVEL),
+            List.of(CommunicateChannel.PHONE, CommunicateChannel.EMAIL),
+            List.of(OnlineActivity.DELIVERY, OnlineActivity.GOVERNMENT),
+            List.of(FinancialChannel.MOBILE_BANKING, FinancialChannel.EASY_PAY),
+            FamilyType.WITH_PARENTS
+        );
+    }
+}


### PR DESCRIPTION
## 관련 이슈
Closes #12 

## 작업 내용
- 내 정보 조회 API
- 내 정보 수정 API
- 온보딩 API

## 변경 사항
- UserProfile column 수정
- Occupation enum 추가
- 테스트에 경고문구 -> build.gradle에 미래 JDK 대비 정적 -javaagent 설정
    - Mockito 관련 안내(경고 문구에서 안내하는 공식 경로): [Mockito javadoc](https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3)

## 체크리스트
- [x] 코드 포맷팅(Checkstyle, Lint 등)을 적용하였는가?
- [x] 테스트 코드를 작성하고 통과했는가?
- [x] 불필요한 console.log / print 등을 제거했는가?
- [x] 로컬 테스트를 완료했는가?
- [x] 관련 서비스 동작을 확인했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 인증된 사용자의 프로필 정보 조회 및 수정 기능 추가
  * 온보딩 기능 추가 - 직업, 성별, 나이대, 경제활동, 소통채널, 온라인활동, 금융채널 등의 사용자 정보 등록 및 계정 활성화 지원

* **Refactor**
  * 사용자 프로필 엔티티 설계 개선 및 데이터 모델 정규화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->