### PR TITLE
[FEAT] 로그인, 로그아웃, 토큰 갱신 api 구현 (#21)

### DIFF
--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/controller/AuthController.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/controller/AuthController.java
@@ -61,4 +61,10 @@ public class AuthController {
         authService.logout(request, userId);
         return ApiResponse.success(null);
     }
+
+    @PostMapping("/logout/all")
+    public ApiResponse<Void> logoutAll(@AuthenticationPrincipal Long userId) {
+        authService.logoutAll(userId);
+        return ApiResponse.success(null);
+    }
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/controller/AuthController.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/controller/AuthController.java
@@ -11,6 +11,7 @@ import com.sos.backend.global.common.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -50,5 +51,14 @@ public class AuthController {
     public ApiResponse<RefreshResponse> refresh(@Valid @RequestBody RefreshRequest request) {
         RefreshResponse response = authService.refresh(request);
         return ApiResponse.success(response);
+    }
+
+    @PostMapping("/logout")
+    public ApiResponse<Void> logout(
+        @Valid @RequestBody LogoutRequest request,
+        @AuthenticationPrincipal Long userId
+    ) {
+        authService.logout(request, userId);
+        return ApiResponse.success(null);
     }
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/controller/AuthController.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/controller/AuthController.java
@@ -1,11 +1,9 @@
 package com.sos.backend.domain.auth.controller;
 
-import com.sos.backend.domain.auth.dto.request.EmailSendRequest;
-import com.sos.backend.domain.auth.dto.request.EmailVerifyRequest;
-import com.sos.backend.domain.auth.dto.request.LoginRequest;
-import com.sos.backend.domain.auth.dto.request.SignupRequest;
+import com.sos.backend.domain.auth.dto.request.*;
 import com.sos.backend.domain.auth.dto.response.EmailVerifyResponse;
 import com.sos.backend.domain.auth.dto.response.LoginResponse;
+import com.sos.backend.domain.auth.dto.response.RefreshResponse;
 import com.sos.backend.domain.auth.dto.response.SignupResponse;
 import com.sos.backend.domain.auth.service.AuthService;
 import com.sos.backend.domain.auth.service.EmailVerificationService;
@@ -45,6 +43,12 @@ public class AuthController {
     @PostMapping("/login")
     public ApiResponse<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
         LoginResponse response = authService.login(request);
+        return ApiResponse.success(response);
+    }
+
+    @PostMapping("/refresh")
+    public ApiResponse<RefreshResponse> refresh(@Valid @RequestBody RefreshRequest request) {
+        RefreshResponse response = authService.refresh(request);
         return ApiResponse.success(response);
     }
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/controller/AuthController.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/controller/AuthController.java
@@ -2,8 +2,10 @@ package com.sos.backend.domain.auth.controller;
 
 import com.sos.backend.domain.auth.dto.request.EmailSendRequest;
 import com.sos.backend.domain.auth.dto.request.EmailVerifyRequest;
+import com.sos.backend.domain.auth.dto.request.LoginRequest;
 import com.sos.backend.domain.auth.dto.request.SignupRequest;
 import com.sos.backend.domain.auth.dto.response.EmailVerifyResponse;
+import com.sos.backend.domain.auth.dto.response.LoginResponse;
 import com.sos.backend.domain.auth.dto.response.SignupResponse;
 import com.sos.backend.domain.auth.service.AuthService;
 import com.sos.backend.domain.auth.service.EmailVerificationService;
@@ -40,4 +42,9 @@ public class AuthController {
         return ApiResponse.success(response);
     }
 
+    @PostMapping("/login")
+    public ApiResponse<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
+        LoginResponse response = authService.login(request);
+        return ApiResponse.success(response);
+    }
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/dto/request/LoginRequest.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/dto/request/LoginRequest.java
@@ -1,0 +1,14 @@
+package com.sos.backend.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+    @NotBlank(message = "이메일을 입력해주세요")
+    @Email(message = "이메일 형식이 올바르지 않습니다")
+    String email,
+
+    @NotBlank(message = "비밀번호를 입력해주세요")
+    String password
+) {
+}

--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/dto/request/LogoutRequest.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/dto/request/LogoutRequest.java
@@ -1,0 +1,9 @@
+package com.sos.backend.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LogoutRequest(
+    @NotBlank(message = "리프레시 토큰은 필수입니다")
+    String refreshToken
+) {
+}

--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/dto/request/RefreshRequest.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/dto/request/RefreshRequest.java
@@ -1,0 +1,9 @@
+package com.sos.backend.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshRequest(
+    @NotBlank(message = "리프레시 토큰은 필수입니다")
+    String refreshToken
+) {
+}

--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/dto/response/LoginResponse.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/dto/response/LoginResponse.java
@@ -1,7 +1,6 @@
 package com.sos.backend.domain.auth.dto.response;
 
 import com.sos.backend.domain.user.enums.Role;
-import jakarta.validation.constraints.Email;
 
 public record LoginResponse(
     String accessToken,

--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/dto/response/LoginResponse.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/dto/response/LoginResponse.java
@@ -1,0 +1,17 @@
+package com.sos.backend.domain.auth.dto.response;
+
+import com.sos.backend.domain.user.enums.Role;
+import jakarta.validation.constraints.Email;
+
+public record LoginResponse(
+    String accessToken,
+    String refreshToken,
+    UserInfo user
+) {
+    public record UserInfo(
+        Long id,
+        String email,
+        String name,
+        Role role
+    ) {}
+}

--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/dto/response/RefreshResponse.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/dto/response/RefreshResponse.java
@@ -1,0 +1,7 @@
+package com.sos.backend.domain.auth.dto.response;
+
+public record RefreshResponse(
+    String accessToken,
+    String refreshToken
+) {
+}

--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/entity/RefreshToken.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/entity/RefreshToken.java
@@ -40,6 +40,7 @@ public class RefreshToken extends BaseEntity {
     private LocalDateTime expiredAt;
 
     @Column(name = "revoked", nullable = false)
+    @Setter
     @Builder.Default
     private Boolean revoked = false;
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/repository/RefreshTokenRepository.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/repository/RefreshTokenRepository.java
@@ -1,7 +1,9 @@
 package com.sos.backend.domain.auth.repository;
 
 import com.sos.backend.domain.auth.entity.RefreshToken;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<RefreshToken> findByTokenHash(String token);
 
     @Modifying

--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/repository/RefreshTokenRepository.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/repository/RefreshTokenRepository.java
@@ -2,6 +2,16 @@ package com.sos.backend.domain.auth.repository;
 
 import com.sos.backend.domain.auth.entity.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByTokenHash(String token);
+
+    @Modifying
+    @Query("Update RefreshToken rt SET rt.revoked = true WHERE rt.user.id = :userId AND rt.revoked = false")
+    int revokeAllByUserId(@Param("userId") long userId);
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/service/AuthService.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/service/AuthService.java
@@ -180,4 +180,8 @@ public class AuthService {
     public void logout(LogoutRequest request, Long userId) {
         refreshTokenService.revoke(request.refreshToken(), userId);
     }
+
+    public void logoutAll(Long userId) {
+        refreshTokenService.revokeAllByUserId(userId);
+    }
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/service/AuthService.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/service/AuthService.java
@@ -1,7 +1,9 @@
 package com.sos.backend.domain.auth.service;
 
 import com.sos.backend.domain.auth.PasswordProperties;
+import com.sos.backend.domain.auth.dto.request.LoginRequest;
 import com.sos.backend.domain.auth.dto.request.SignupRequest;
+import com.sos.backend.domain.auth.dto.response.LoginResponse;
 import com.sos.backend.domain.auth.dto.response.SignupResponse;
 import com.sos.backend.domain.auth.entity.AuthProvider;
 import com.sos.backend.domain.auth.enums.Provider;
@@ -15,6 +17,7 @@ import com.sos.backend.global.auth.JwtProvider;
 import com.sos.backend.global.auth.VerificationTokenProvider;
 import com.sos.backend.global.common.exception.CustomException;
 import com.sos.backend.global.common.exception.ErrorCode;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -23,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -35,6 +39,13 @@ public class AuthService {
     private final AuthProviderRepository authProviderRepository;
     private final JwtProvider jwtProvider;
     private final RefreshTokenService refreshTokenService;
+
+    private String dummyHash;
+
+    @PostConstruct
+    private void initDummyHash() {
+        this.dummyHash = passwordEncoder.encode("dummy");
+    }
 
     @Transactional
     public SignupResponse signup(SignupRequest request) {
@@ -85,6 +96,49 @@ public class AuthService {
             accessToken,
             refreshToken,
             new SignupResponse.UserInfo(
+                user.getId(),
+                user.getEmail(),
+                user.getName(),
+                user.getRole()
+            )
+        );
+    }
+
+    @Transactional
+    public LoginResponse login(LoginRequest request) {
+        // 1. 이메일로 user 조회
+        Optional<User> userOpt = userRepository.findByEmail(request.email());
+
+        // 2. user 없으면 더미 해시로 BCrypt 비교 후 실패 (timing attack 방어)
+        if (userOpt.isEmpty()) {
+            passwordEncoder.matches(request.password(), dummyHash);
+            throw new CustomException(ErrorCode.INVALID_CREDENTIALS);
+        }
+
+        User user = userOpt.get();
+
+        // 3. 비밀번호 비교
+        if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+            throw new CustomException(ErrorCode.INVALID_CREDENTIALS);
+        }
+
+        // 4. 계정 상태 검증 (ACTIVE만 로그인 허용)
+        if (user.getStatus() != UserStatus.ACTIVE) {
+            throw new CustomException(ErrorCode.INVALID_CREDENTIALS);
+        }
+
+        // 5. lastLoginAt 갱신
+        user.setLastLoginAt(LocalDateTime.now());
+
+        // 6. Access/Refresh Token 발급
+        String accessToken = jwtProvider.createAccessToken(user.getId(), user.getEmail());
+        String refreshToken = refreshTokenService.issue(user);
+
+        // 7. 응답 구성
+        return new LoginResponse(
+            accessToken,
+            refreshToken,
+            new LoginResponse.UserInfo(
                 user.getId(),
                 user.getEmail(),
                 user.getName(),

--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/service/AuthService.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/service/AuthService.java
@@ -2,8 +2,10 @@ package com.sos.backend.domain.auth.service;
 
 import com.sos.backend.domain.auth.PasswordProperties;
 import com.sos.backend.domain.auth.dto.request.LoginRequest;
+import com.sos.backend.domain.auth.dto.request.RefreshRequest;
 import com.sos.backend.domain.auth.dto.request.SignupRequest;
 import com.sos.backend.domain.auth.dto.response.LoginResponse;
+import com.sos.backend.domain.auth.dto.response.RefreshResponse;
 import com.sos.backend.domain.auth.dto.response.SignupResponse;
 import com.sos.backend.domain.auth.entity.AuthProvider;
 import com.sos.backend.domain.auth.enums.Provider;
@@ -145,6 +147,18 @@ public class AuthService {
                 user.getRole()
             )
         );
+    }
+
+    public RefreshResponse refresh(RefreshRequest request) {
+        // 1. Refresh Token Rotation (검증 + 재사용 감지 + 새 refresh token 발급)
+        String newRefreshToken = refreshTokenService.rotate(request.refreshToken());
+
+        // 2. 새 refresh token에서 user 정보 추출하여 access token 발급
+        Long userId = jwtProvider.getUserId(newRefreshToken);
+        String email = jwtProvider.getEmail(newRefreshToken);
+        String newAccessToken = jwtProvider.createAccessToken(userId, email);
+
+        return new RefreshResponse(newAccessToken, newRefreshToken);
     }
 
     private void validatePasswordLength(String password) {

--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/service/AuthService.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/service/AuthService.java
@@ -2,6 +2,7 @@ package com.sos.backend.domain.auth.service;
 
 import com.sos.backend.domain.auth.PasswordProperties;
 import com.sos.backend.domain.auth.dto.request.LoginRequest;
+import com.sos.backend.domain.auth.dto.request.LogoutRequest;
 import com.sos.backend.domain.auth.dto.request.RefreshRequest;
 import com.sos.backend.domain.auth.dto.request.SignupRequest;
 import com.sos.backend.domain.auth.dto.response.LoginResponse;
@@ -174,5 +175,9 @@ public class AuthService {
         if (byteLength > passwordProperties.maxLength()) {
             throw new CustomException(ErrorCode.INVALID_PASSWORD_LENGTH);
         }
+    }
+
+    public void logout(LogoutRequest request, Long userId) {
+        refreshTokenService.revoke(request.refreshToken(), userId);
     }
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/service/LoginService.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/service/LoginService.java
@@ -1,4 +1,0 @@
-package com.sos.backend.domain.auth.service;
-
-public class LoginService {
-}

--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/service/LoginService.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/service/LoginService.java
@@ -1,0 +1,4 @@
+package com.sos.backend.domain.auth.service;
+
+public class LoginService {
+}

--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/service/RefreshTokenService.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/service/RefreshTokenService.java
@@ -11,8 +11,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.time.Duration;
-import java.time.LocalDateTime;
 import java.util.HexFormat;
 
 @Service
@@ -35,7 +33,7 @@ public class RefreshTokenService {
         RefreshToken entity = RefreshToken.builder()
             .user(user)
             .tokenHash(tokenHash)
-            .expiredAt(LocalDateTime.now().plus(Duration.ofMillis(jwtProvider.getRefreshTokenExpirationMillis())))  // 14일
+            .expiredAt(jwtProvider.extractExpiry(refreshToken))
             .build();
 
         refreshTokenRepository.save(entity);

--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/service/RefreshTokenService.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/service/RefreshTokenService.java
@@ -64,6 +64,39 @@ public class RefreshTokenService {
         return issue(stored.getUser());
     }
 
+    /**
+     * 단일 Refresh Token 폐기 (logout).
+     * 본인 user의 토큰인지 검증하여 위조 요청 차단.
+     */
+    @Transactional
+    public void revoke(String refreshToken, Long userId) {
+        // 1. JWT 자체 검증 (만료/위조 시 throw)
+        jwtProvider.validateOrThrow(refreshToken);
+
+        // 2. tokenHash로 DB 조회
+        String tokenHash = sha256(refreshToken);
+        RefreshToken stored = refreshTokenRepository.findByTokenHash(tokenHash)
+            .orElseThrow(() -> new CustomException(ErrorCode.INVALID_TOKEN));
+
+        // 3. 본인 토큰 검증
+        if (!stored.getUser().getId().equals(userId)) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+
+        // 4. revoke (이미 revoked여도 멱등 — silent success)
+        if (Boolean.FALSE.equals(stored.getRevoked())) {
+            stored.setRevoked(true);
+        }
+    }
+
+    /**
+     * user의 모든 Refresh Token 일괄 폐기 (logout-all).
+     */
+    @Transactional
+    public void revokeAllByUserId(Long userId) {
+        refreshTokenRepository.revokeAllByUserId(userId);
+    }
+
     private String sha256(String input) {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");

--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/service/RefreshTokenService.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/service/RefreshTokenService.java
@@ -4,6 +4,8 @@ import com.sos.backend.domain.auth.entity.RefreshToken;
 import com.sos.backend.domain.auth.repository.RefreshTokenRepository;
 import com.sos.backend.domain.user.entity.User;
 import com.sos.backend.global.auth.JwtProvider;
+import com.sos.backend.global.common.exception.CustomException;
+import com.sos.backend.global.common.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,6 +41,27 @@ public class RefreshTokenService {
         refreshTokenRepository.save(entity);
 
         return refreshToken;
+    }
+
+    @Transactional(noRollbackFor = CustomException.class)
+    public String rotate(String refreshToken) {
+        // 1. JWT 자체 검증 (만료/위조 시 throw)
+        jwtProvider.validateOrThrow(refreshToken);
+
+        // 2. tokenHash로 DB 조회
+        String tokenHash = sha256(refreshToken);
+        RefreshToken stored = refreshTokenRepository.findByTokenHash(tokenHash)
+            .orElseThrow(() -> new CustomException(ErrorCode.INVALID_TOKEN));
+
+        // 3. 재사용 감지
+        if (Boolean.TRUE.equals(stored.getRevoked())) {
+            refreshTokenRepository.revokeAllByUserId(stored.getUser().getId());
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+
+        // 4. 정상 흐름 (토큰 재발행)
+        stored.setRevoked(true);
+        return issue(stored.getUser());
     }
 
     private String sha256(String input) {

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/entity/User.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/entity/User.java
@@ -47,5 +47,6 @@ public class User extends BaseEntity {
     private LocalDateTime withdrawnAt;
 
     @Column(name = "last_login_at")
+    @Setter
     private LocalDateTime lastLoginAt;
 }

--- a/apps/backend/src/main/java/com/sos/backend/global/auth/JwtProperties.java
+++ b/apps/backend/src/main/java/com/sos/backend/global/auth/JwtProperties.java
@@ -1,0 +1,15 @@
+package com.sos.backend.global.auth;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@ConfigurationProperties(prefix = "jwt")
+@Validated
+public record JwtProperties(
+    @NotBlank String secret,
+    @Positive long accessTokenExpiration,
+    @Positive long refreshTokenExpiration
+) {
+}

--- a/apps/backend/src/main/java/com/sos/backend/global/auth/JwtProvider.java
+++ b/apps/backend/src/main/java/com/sos/backend/global/auth/JwtProvider.java
@@ -3,7 +3,6 @@ package com.sos.backend.global.auth;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import com.sos.backend.global.common.exception.CustomException;
 import com.sos.backend.global.common.exception.ErrorCode;
@@ -11,6 +10,9 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 
 import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Date;
 
 @Component
@@ -20,13 +22,10 @@ public class JwtProvider {
     private final long accessTokenExpiration;
     private final long refreshTokenExpiration;
 
-    public JwtProvider(
-        @Value("${jwt.secret}") String secret,
-        @Value("${jwt.access-token-expiration}") long accessTokenExpiration,
-        @Value("${jwt.refresh-token-expiration}") long refreshTokenExpiration) {
-        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes());
-        this.accessTokenExpiration = accessTokenExpiration;
-        this.refreshTokenExpiration = refreshTokenExpiration;
+    public JwtProvider(JwtProperties jwtProperties) {
+        this.secretKey = Keys.hmacShaKeyFor(jwtProperties.secret().getBytes(StandardCharsets.UTF_8));
+        this.accessTokenExpiration = jwtProperties.accessTokenExpiration();
+        this.refreshTokenExpiration = jwtProperties.refreshTokenExpiration();
     }
 
     // Access Token 생성
@@ -60,11 +59,28 @@ public class JwtProvider {
         return getClaims(token).get("email", String.class);
     }
 
+    // 토큰의 만료 시각 추출
+    public LocalDateTime extractExpiry(String token) {
+        Date expiration = getClaims(token).getExpiration();
+        return expiration.toInstant()
+            .atZone(ZoneId.systemDefault())
+            .toLocalDateTime();
+    }
+
     // 토큰 유효성 검증
     public boolean validateToken(String token) {
         try {
             getClaims(token);
             return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    // 토큰 유효성 검증하고, 실패 시 만료/위조 구분된 CustomException throw
+    public void validateOrThrow(String token) {
+        try {
+            getClaims(token);
         } catch (ExpiredJwtException e) {
             throw new CustomException(ErrorCode.EXPIRED_TOKEN);
         } catch (JwtException | IllegalArgumentException e) {
@@ -79,10 +95,5 @@ public class JwtProvider {
             .build()
             .parseSignedClaims(token)
             .getPayload();
-    }
-
-    // 리프레시토큰 만료 기간 리턴
-    public long getRefreshTokenExpirationMillis() {
-        return refreshTokenExpiration;
     }
 }

--- a/apps/backend/src/main/java/com/sos/backend/global/common/config/SecurityConfig.java
+++ b/apps/backend/src/main/java/com/sos/backend/global/common/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -30,7 +31,9 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-            .csrf(csrf -> csrf.disable())
+            .csrf(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .httpBasic(AbstractHttpConfigurer::disable)
             .sessionManagement(session -> session
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
@@ -38,7 +41,10 @@ public class SecurityConfig {
                     "/swagger-ui/**",
                     "/api-docs/**",
                     "/swagger-ui.html",
-                    "/api/v1/auth/**"
+                    "/api/v1/auth/email/**",
+                    "/api/v1/auth/signup",
+                    "/api/v1/auth/login",
+                    "/api/v1/auth/refresh"
                 ).permitAll()
                 .anyRequest().authenticated()
             )

--- a/apps/backend/src/main/java/com/sos/backend/global/common/exception/ErrorCode.java
+++ b/apps/backend/src/main/java/com/sos/backend/global/common/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     // Auth
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다"),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다"),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다"),
 
     // Email Verification
     EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 발송에 실패했습니다"),


### PR DESCRIPTION
## 관련 이슈
Closes #21 

## 작업 내용
로그인, 로그아웃, 토큰 갱신 api 구현
- JWT 토큰 라이프사이클 관리(Rotation, 재사용 감지, logout/all) 구현.

## 작업 흐름 (Phase별)

### Phase 0 — 기반 정비
부수 작업으로 endpoint 구현 중 끊기지 않도록 먼저 처리.
- RefreshToken 엔티티 `revoked` setter 추가 (필드별 @Setter 패턴)
- SecurityConfig 매처 세분화: `/auth/email/**`, `/auth/refresh` 추가, `formLogin`/`httpBasic` 명시적 disable
- JwtProvider 리팩토링
  - `extractExpiry()` 메서드 추가 (JWT exp claim을 ground truth로)
  - `validateToken()` (boolean) / `validateOrThrow()` (void + throw) 메서드 분리
  - `@Value` → `@ConfigurationProperties` 마이그레이션
  - `secret.getBytes()` → UTF-8 charset 명시
- JwtProperties record 신규 생성
- RefreshTokenService 신규 생성 (`issue()`)

### Phase 1 — Login (`POST /auth/login`)
- LoginRequest, LoginResponse DTO
- `INVALID_CREDENTIALS` ErrorCode 추가
- BCrypt 검증 + 더미 해시 비교 (timing attack 방어)
- 비밀번호 → 상태 검증 순서 (OWASP 권장)
- lastLoginAt 갱신 (dirty checking)

### Phase 2 — Refresh (`POST /auth/refresh`)
- RefreshRequest, RefreshResponse DTO
- RefreshTokenRepository (`findByTokenHash`, `revokeAllByUserId`)
- RefreshTokenService.rotate() — Rotation + 재사용 감지
- JWT 자체 검증 → DB 조회 → revoked 체크 → 재사용 시 user의 모든 토큰 폐기

### Phase 3 — Logout (`POST /auth/logout`)
- LogoutRequest DTO
- RefreshTokenService.revoke() — 본인 토큰 검증 + 멱등성
- `@AuthenticationPrincipal Long userId` 활용

### Phase 4 — Logout All (`POST /auth/logout/all`)
- 단순 wrapper (Phase 3에서 `revokeAllByUserId` 미리 추가해둠)
- request body 없음 (access token에서 user_id 추출)

## 핵심 학습

### 1. 트랜잭션 속성 적용 시점 함정 (실제 디버깅)
`RefreshTokenService.rotate()`에 `@Transactional(noRollbackFor = CustomException.class)`을 걸었지만 재사용 감지 시 `revokeAllByUserId` 호출이 롤백되는 문제 발생.

원인: `AuthService.refresh()`의 `@Transactional`이 먼저 트랜잭션을 시작 → default propagation = REQUIRED → 내부 `rotate()`의 `noRollbackFor` 속성 무시.

해결: `AuthService.refresh()`의 `@Transactional` 제거하여 `rotate()`가 트랜잭션 시작점이 되도록 함.

일반 원칙: **`@Transactional`의 트랜잭션 속성은 트랜잭션 시작 시점에만 적용된다.** 보안 카운터처럼 "throw해도 롤백되지 말아야 할" 작업은 트랜잭션 경계 설계가 핵심.

### 2. JWT 로그아웃의 본질
stateless 특성으로 즉시 무효화 불가. 서버는 `refresh_token.revoked = true`로 탈취 방어, 클라이언트는 로컬 토큰 삭제 + 로그인 화면 이동으로 UX 처리. access_token은 만료까지 유효한 점진적 로그아웃 모델.

### 3. JwtProvider의 use case별 메서드 분리
- `validateToken()` (boolean) — JwtFilter용. 통과 여부만 판단, 실패는 401로 단일 처리
- `validateOrThrow()` (void + throw) — refresh endpoint용. 만료/위조 구분된 ErrorCode 응답이 필요한 경우

호출 시점에 어떤 메서드 쓸지 자명. "throw 후 catch로 무시"하는 어색함 없음.

### 4. JPA `@Modifying` + `clearAutomatically`
JPQL UPDATE는 1차 캐시 우회 → 같은 트랜잭션 내 후속 조회 시 stale 캐시 가능성. `clearAutomatically = true`로 방어.

## 체크리스트
- [x] 코드 포맷팅(Checkstyle, Lint 등)을 적용하였는가?
- [ ] 테스트 코드를 작성하고 통과했는가? (통합 테스트 인프라 보강 후 별도 chore PR로 진행)
- [x] 불필요한 console.log / print 등을 제거했는가?
- [x] 로컬 테스트를 완료했는가?
- [x] 관련 서비스 동작을 확인했는가?

## 테스트
IntelliJ HTTP Client로 4개 endpoint 수동 검증.

### Login
- 정상 로그인 → access + refresh + UserInfo 발급 확인
- 잘못된 비밀번호 → 401 INVALID_CREDENTIALS
- 존재하지 않는 이메일 → 401 INVALID_CREDENTIALS (이메일 존재 여부 노출 X 확인)

### Refresh
- 정상 Rotation → 새 access + refresh, 기존 token revoked 확인
- 재사용 감지 → 이미 revoked된 token으로 호출 시 user의 모든 token revoked, 401 응답
- 위조된 토큰 → 401 INVALID_TOKEN

### Logout
- 정상 logout → 200 OK, refresh_token revoked 확인
- 본인 토큰 검증 → 다른 user의 refresh_token 보내면 401 INVALID_TOKEN
- 멱등성 → 같은 토큰으로 두 번 logout해도 200 OK
- 인증 없이 호출 → 차단 (현재 403, 401 응답 표준화는 별도 chore)

### Logout All
- 정상 호출 → 200 OK, user의 모든 refresh_token revoked 확인

## 리뷰 포인트
### 이번 PR에서 안 한 것
- Google OAuth2
- 통합 테스트 → 인프라 보강 chore PR 후 별도 처리 (재사용 감지 시나리오 테스트 포함)
- Swagger 어노테이션 → 별도 chore PR (auth 도메인 전체 한 번에)
- Properties 패키지 정리 → 별도 chore PR (`domain/auth/`, `global/auth/` 둘 다 묶어서)
- 인증/인가 실패 응답 표준화 (현재 401 누락 시 403 응답) → 별도 chore PR
- Refresh Token cleanup 배치 → 별도 chore PR (운영 단계 결정과 함께)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 이메일과 비밀번호를 사용한 로그인 기능이 추가되었습니다.
* 액세스 토큰을 갱신할 수 있는 토큰 새로고침 기능이 추가되었습니다.
* 현재 세션에서만 로그아웃하거나 모든 세션에서 동시에 로그아웃하는 기능이 추가되었습니다.
* 인증 보안이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->