### PR TITLE
[Refactor] 회원 상태관리 전략 변경에 따른 리팩토링

### DIFF
--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/service/AuthService.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/service/AuthService.java
@@ -22,6 +22,7 @@ import com.sos.backend.global.common.exception.CustomException;
 import com.sos.backend.global.common.exception.ErrorCode;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -32,6 +33,7 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class AuthService {
 
@@ -72,14 +74,18 @@ public class AuthService {
             .email(email)
             .password(hashedPassword)
             .name(request.name())
-            .role(Role.USER)
+            .role(Role.GUEST)
             .status(UserStatus.ACTIVE)
             .lastLoginAt(LocalDateTime.now())
             .build();
         try {
             userRepository.save(user);
         } catch (DataIntegrityViolationException e) {
-            throw new CustomException(ErrorCode.EMAIL_ALREADY_EXISTS);
+            if (userRepository.existsByEmail(email)) {
+                throw new CustomException(ErrorCode.EMAIL_ALREADY_EXISTS);
+            }
+            log.error("회원가입 중 users 저장 실패 - email: {}", email, e);
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
 
         // 5. AuthProvider(LOCAL) 생성 + 저장
@@ -91,7 +97,7 @@ public class AuthService {
         authProviderRepository.save(authProvider);
 
         // 6. Access/Refresh Token 발급 (자동 로그인)
-        String accessToken = jwtProvider.createAccessToken(user.getId(), user.getEmail());
+        String accessToken = jwtProvider.createAccessToken(user.getId(), user.getEmail(), user.getRole());
         String refreshToken = refreshTokenService.issue(user);
 
         // 7. 응답 구성
@@ -134,7 +140,7 @@ public class AuthService {
         user.setLastLoginAt(LocalDateTime.now());
 
         // 6. Access/Refresh Token 발급
-        String accessToken = jwtProvider.createAccessToken(user.getId(), user.getEmail());
+        String accessToken = jwtProvider.createAccessToken(user.getId(), user.getEmail(), user.getRole());
         String refreshToken = refreshTokenService.issue(user);
 
         // 7. 응답 구성

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/controller/UserController.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/controller/UserController.java
@@ -1,13 +1,13 @@
 package com.sos.backend.domain.user.controller;
 
 import com.sos.backend.domain.user.dto.OnboardingRequest;
+import com.sos.backend.domain.user.dto.OnboardingResponse;
 import com.sos.backend.domain.user.dto.UserActionResponse;
 import com.sos.backend.domain.user.dto.UserInfoResponse;
 import com.sos.backend.domain.user.dto.UserUpdateRequest;
 import com.sos.backend.domain.user.service.UserService;
 import com.sos.backend.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -50,13 +50,16 @@ public class UserController {
     }
 
     @PostMapping("/onboarding")
-    @Operation(summary = "온보딩", description = "온보딩 설문을 저장하고 사용자 상태를 ACTIVE로 변경합니다.")
+    @Operation(
+        summary = "온보딩 완료",
+        description = "온보딩 설문을 저장하고 사용자 권한을 GUEST에서 USER로 승격한 뒤, 변경된 권한이 반영된 JWT 토큰을 재발급합니다."
+    )
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "온보딩 완료")
-    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 입력값 또는 이미 온보딩 완료된 사용자",
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 입력값 또는 이미 USER 권한인 사용자",
         content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유저 또는 프로필을 찾을 수 없음",
         content = @Content(schema = @Schema(implementation = ApiResponse.class)))
-    public ApiResponse<UserActionResponse> onboard(
+    public ApiResponse<OnboardingResponse> onboard(
         @AuthenticationPrincipal Long userId,
         @Valid @RequestBody OnboardingRequest request
     ) {

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/dto/OnboardingResponse.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/dto/OnboardingResponse.java
@@ -1,0 +1,24 @@
+package com.sos.backend.domain.user.dto;
+
+import com.sos.backend.domain.user.entity.User;
+import com.sos.backend.domain.user.enums.Role;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "온보딩 완료 응답")
+public record OnboardingResponse(
+    @Schema(description = "처리 결과 메시지", example = "온보딩이 완료되었습니다.")
+    String message,
+
+    @Schema(description = "재발급된 Access Token", example = "eyJhbGciOiJIUzI1NiJ9...")
+    String accessToken,
+
+    @Schema(description = "재발급된 Refresh Token", example = "eyJhbGciOiJIUzI1NiJ9...")
+    String refreshToken,
+
+    @Schema(description = "온보딩 완료 후 사용자 역할", example = "USER")
+    Role role
+) {
+    public static OnboardingResponse of(String message, String accessToken, String refreshToken, User user) {
+        return new OnboardingResponse(message, accessToken, refreshToken, user.getRole());
+    }
+}

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/dto/UserActionResponse.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/dto/UserActionResponse.java
@@ -2,7 +2,7 @@ package com.sos.backend.domain.user.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(description = "수정/온보딩 완료 응답")
+@Schema(description = "내 정보 수정 완료 응답")
 public record UserActionResponse(
     @Schema(description = "처리 결과 메시지", example = "내 정보가 수정되었습니다.")
     String message

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/entity/User.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/entity/User.java
@@ -53,4 +53,8 @@ public class User extends BaseEntity {
     public void changeStatus(UserStatus status) {
         this.status = status;
     }
+
+    public void changeRole(Role role) {
+        this.role = role;
+    }
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/entity/UserProfile.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/entity/UserProfile.java
@@ -32,9 +32,6 @@ public class UserProfile extends BaseEntity {
     @Column(name = "occupation", length = 30)
     private Occupation occupation;
 
-    @Column(name = "birth")
-    private Integer birth;
-
     @Enumerated(EnumType.STRING)
     @Column(name = "gender", length = 10)
     private Gender gender;

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/enums/Role.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/enums/Role.java
@@ -1,5 +1,5 @@
 package com.sos.backend.domain.user.enums;
 
 public enum Role {
-    USER, ADMIN
+    GUEST, USER, ADMIN
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/enums/UserStatus.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/enums/UserStatus.java
@@ -1,5 +1,5 @@
 package com.sos.backend.domain.user.enums;
 
 public enum UserStatus {
-    ACTIVE, INACTIVE, ONBOARDING, WITHDRAWN
+    ACTIVE, INACTIVE, WITHDRAWN
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/service/UserService.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.sos.backend.domain.user.service;
 
 import com.sos.backend.domain.user.dto.OnboardingRequest;
+import com.sos.backend.domain.user.dto.OnboardingResponse;
 import com.sos.backend.domain.user.dto.UserActionResponse;
 import com.sos.backend.domain.user.dto.UserInfoResponse;
 import com.sos.backend.domain.user.dto.UserUpdateRequest;
@@ -10,9 +11,11 @@ import com.sos.backend.domain.user.enums.CommunicateChannel;
 import com.sos.backend.domain.user.enums.EconomicActivity;
 import com.sos.backend.domain.user.enums.FinancialChannel;
 import com.sos.backend.domain.user.enums.OnlineActivity;
-import com.sos.backend.domain.user.enums.UserStatus;
+import com.sos.backend.domain.user.enums.Role;
 import com.sos.backend.domain.user.repository.UserProfileRepository;
 import com.sos.backend.domain.user.repository.UserRepository;
+import com.sos.backend.domain.auth.service.RefreshTokenService;
+import com.sos.backend.global.auth.JwtProvider;
 import com.sos.backend.global.common.exception.CustomException;
 import com.sos.backend.global.common.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +23,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +31,8 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final UserProfileRepository userProfileRepository;
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenService refreshTokenService;
 
     public UserInfoResponse getMyInfo(Long userId) {
         User user = getUser(userId);
@@ -46,13 +50,12 @@ public class UserService {
     }
 
     @Transactional
-    public UserActionResponse onboard(Long userId, OnboardingRequest request) {
+    public OnboardingResponse onboard(Long userId, OnboardingRequest request) {
         User user = getUser(userId);
-        UserProfile profile = getUserProfile(userId);
-
-        if (!Set.of(UserStatus.ONBOARDING, UserStatus.INACTIVE).contains(user.getStatus())) {
+        if (user.getRole() == Role.USER) {
             throw new CustomException(ErrorCode.INVALID_INPUT);
         }
+        UserProfile profile = getOrCreateUserProfile(user);
 
         profile.completeOnboarding(
             request.occupation(),
@@ -64,9 +67,12 @@ public class UserService {
             request.financialChannels().stream().map(FinancialChannel::code).toList(),
             List.of(request.familyType().code())
         );
-        user.changeStatus(UserStatus.ACTIVE);
+        user.changeRole(Role.USER);
 
-        return UserActionResponse.of("온보딩이 완료되었습니다.");
+        String newAccessToken = jwtProvider.createAccessToken(user.getId(), user.getEmail(), user.getRole());
+        String newRefreshToken = refreshTokenService.issue(user);
+
+        return OnboardingResponse.of("온보딩이 완료되었습니다.", newAccessToken, newRefreshToken, user);
     }
 
     private User getUser(Long userId) {
@@ -77,5 +83,15 @@ public class UserService {
     private UserProfile getUserProfile(Long userId) {
         return userProfileRepository.findByUserId(userId)
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+    }
+
+    private UserProfile getOrCreateUserProfile(User user) {
+        return userProfileRepository.findByUserId(user.getId())
+            .orElseGet(() -> userProfileRepository.save(
+                UserProfile.builder()
+                    .user(user)
+                    .onboardingCompleted(false)
+                    .build()
+            ));
     }
 }

--- a/apps/backend/src/main/java/com/sos/backend/global/auth/JwtProvider.java
+++ b/apps/backend/src/main/java/com/sos/backend/global/auth/JwtProvider.java
@@ -1,5 +1,6 @@
 package com.sos.backend.global.auth;
 
+import com.sos.backend.domain.user.enums.Role;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -30,23 +31,32 @@ public class JwtProvider {
 
     // Access Token 생성
     public String createAccessToken(Long userId, String email) {
-        return createToken(userId, email, accessTokenExpiration);
+        return createToken(userId, email, null, accessTokenExpiration);
+    }
+
+    public String createAccessToken(Long userId, String email, Role role) {
+        return createToken(userId, email, role, accessTokenExpiration);
     }
 
     // Refresh Token 생성
     public String createRefreshToken(Long userId, String email) {
-        return createToken(userId, email, refreshTokenExpiration);
+        return createToken(userId, email, null, refreshTokenExpiration);
     }
 
     // 토큰 생성
-    private String createToken(Long userId, String email, long expiration) {
-        return Jwts.builder()
+    private String createToken(Long userId, String email, Role role, long expiration) {
+        var builder = Jwts.builder()
             .subject(String.valueOf(userId))
             .claim("email", email)
             .issuedAt(new Date())
             .expiration(new Date(System.currentTimeMillis() + expiration))
-            .signWith(secretKey)
-            .compact();
+            .signWith(secretKey);
+
+        if (role != null) {
+            builder.claim("role", role.name());
+        }
+
+        return builder.compact();
     }
 
     // 토큰에서 userId 추출

--- a/apps/backend/src/main/java/com/sos/backend/global/common/config/SwaggerConfig.java
+++ b/apps/backend/src/main/java/com/sos/backend/global/common/config/SwaggerConfig.java
@@ -2,6 +2,8 @@ package com.sos.backend.global.common.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,6 +13,13 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
+            .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+            .components(new io.swagger.v3.oas.models.Components()
+                .addSecuritySchemes("bearerAuth", new SecurityScheme()
+                    .name("Authorization")
+                    .type(SecurityScheme.Type.HTTP)
+                    .scheme("bearer")
+                    .bearerFormat("JWT")))
             .info(new Info()
                 .title("S.O.S API")
                 .description("Safe or Scam 백엔드 API 명세서")

--- a/apps/backend/src/test/java/com/sos/backend/domain/user/service/UserServiceTest.java
+++ b/apps/backend/src/test/java/com/sos/backend/domain/user/service/UserServiceTest.java
@@ -1,6 +1,8 @@
 package com.sos.backend.domain.user.service;
 
+import com.sos.backend.domain.auth.service.RefreshTokenService;
 import com.sos.backend.domain.user.dto.OnboardingRequest;
+import com.sos.backend.domain.user.dto.OnboardingResponse;
 import com.sos.backend.domain.user.dto.UserActionResponse;
 import com.sos.backend.domain.user.dto.UserInfoResponse;
 import com.sos.backend.domain.user.dto.UserUpdateRequest;
@@ -9,6 +11,7 @@ import com.sos.backend.domain.user.entity.UserProfile;
 import com.sos.backend.domain.user.enums.*;
 import com.sos.backend.domain.user.repository.UserProfileRepository;
 import com.sos.backend.domain.user.repository.UserRepository;
+import com.sos.backend.global.auth.JwtProvider;
 import com.sos.backend.global.common.exception.CustomException;
 import com.sos.backend.global.common.exception.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
@@ -24,6 +27,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -37,6 +41,12 @@ class UserServiceTest {
     @Mock
     private UserProfileRepository userProfileRepository;
 
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
     @InjectMocks
     private UserService userService;
 
@@ -48,7 +58,7 @@ class UserServiceTest {
         @DisplayName("유저와 프로필이 존재하면 기본 정보를 반환한다")
         void getMyInfo_success() {
             Long userId = 1L;
-            User user = createUser(userId, UserStatus.ONBOARDING);
+            User user = createUser(userId, Role.GUEST, UserStatus.ACTIVE);
             UserProfile profile = createProfile(userId, user);
 
             given(userRepository.findById(userId)).willReturn(Optional.of(user));
@@ -86,7 +96,7 @@ class UserServiceTest {
         @DisplayName("직업/성별/연령대를 수정한다")
         void updateMyInfo_success() {
             Long userId = 1L;
-            User user = createUser(userId, UserStatus.ONBOARDING);
+            User user = createUser(userId, Role.GUEST, UserStatus.ACTIVE);
             UserProfile profile = createProfile(userId, user);
             UserUpdateRequest request = new UserUpdateRequest(
                 Occupation.FREELANCER,
@@ -111,15 +121,13 @@ class UserServiceTest {
     class Onboard {
 
         @Test
-        @DisplayName("이미 ACTIVE 상태면 INVALID_INPUT 예외를 던진다")
-        void onboard_alreadyActive() {
+        @DisplayName("이미 USER 권한이면 INVALID_INPUT 예외를 던진다")
+        void onboard_alreadyUserRole() {
             Long userId = 1L;
-            User user = createUser(userId, UserStatus.ACTIVE);
-            UserProfile profile = createProfile(userId, user);
+            User user = createUser(userId, Role.USER, UserStatus.ACTIVE);
             OnboardingRequest request = createOnboardingRequest();
 
             given(userRepository.findById(userId)).willReturn(Optional.of(user));
-            given(userProfileRepository.findByUserId(userId)).willReturn(Optional.of(profile));
 
             assertThatThrownBy(() -> userService.onboard(userId, request))
                 .isInstanceOf(CustomException.class)
@@ -128,37 +136,25 @@ class UserServiceTest {
         }
 
         @Test
-        @DisplayName("WITHDRAWN 상태면 INVALID_INPUT 예외를 던진다")
-        void onboard_withdrawnUser() {
-            Long userId = 1L;
-            User user = createUser(userId, UserStatus.WITHDRAWN);
-            UserProfile profile = createProfile(userId, user);
-            OnboardingRequest request = createOnboardingRequest();
-
-            given(userRepository.findById(userId)).willReturn(Optional.of(user));
-            given(userProfileRepository.findByUserId(userId)).willReturn(Optional.of(profile));
-
-            assertThatThrownBy(() -> userService.onboard(userId, request))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.INVALID_INPUT);
-        }
-
-        @Test
-        @DisplayName("온보딩 완료 시 프로필 저장값을 반영하고 UserStatus를 ACTIVE로 변경한다")
+        @DisplayName("온보딩 완료 시 프로필 저장값 반영, USER 권한 승격, 토큰 재발급을 수행한다")
         void onboard_success() {
             Long userId = 1L;
-            User user = createUser(userId, UserStatus.ONBOARDING);
+            User user = createUser(userId, Role.GUEST, UserStatus.ACTIVE);
             UserProfile profile = createProfile(userId, user);
             OnboardingRequest request = createOnboardingRequest();
 
             given(userRepository.findById(userId)).willReturn(Optional.of(user));
             given(userProfileRepository.findByUserId(userId)).willReturn(Optional.of(profile));
+            given(jwtProvider.createAccessToken(user.getId(), user.getEmail(), Role.USER)).willReturn("new-access-token");
+            given(refreshTokenService.issue(user)).willReturn("new-refresh-token");
 
-            UserActionResponse response = userService.onboard(userId, request);
+            OnboardingResponse response = userService.onboard(userId, request);
 
             assertThat(response.message()).isEqualTo("온보딩이 완료되었습니다.");
-            assertThat(user.getStatus()).isEqualTo(UserStatus.ACTIVE);
+            assertThat(response.accessToken()).isEqualTo("new-access-token");
+            assertThat(response.refreshToken()).isEqualTo("new-refresh-token");
+            assertThat(response.role()).isEqualTo(Role.USER);
+            assertThat(user.getRole()).isEqualTo(Role.USER);
             assertThat(profile.getOnboardingCompleted()).isTrue();
             assertThat(profile.getOccupation()).isEqualTo(Occupation.EMPLOYEE);
             assertThat(profile.getEconomicActivities()).containsExactly("entertainment", "travel");
@@ -169,28 +165,31 @@ class UserServiceTest {
         }
 
         @Test
-        @DisplayName("프로필이 없으면 NOT_FOUND 예외를 던진다")
-        void onboard_profileNotFound() {
+        @DisplayName("프로필이 없으면 생성 후 온보딩을 완료한다")
+        void onboard_createProfileWhenNotFound() {
             Long userId = 1L;
-            User user = createUser(userId, UserStatus.ONBOARDING);
+            User user = createUser(userId, Role.GUEST, UserStatus.ACTIVE);
             OnboardingRequest request = createOnboardingRequest();
 
             given(userRepository.findById(userId)).willReturn(Optional.of(user));
             given(userProfileRepository.findByUserId(userId)).willReturn(Optional.empty());
+            given(userProfileRepository.save(any(UserProfile.class))).willAnswer(invocation -> invocation.getArgument(0));
+            given(jwtProvider.createAccessToken(user.getId(), user.getEmail(), Role.USER)).willReturn("new-access-token");
+            given(refreshTokenService.issue(user)).willReturn("new-refresh-token");
 
-            assertThatThrownBy(() -> userService.onboard(userId, request))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.NOT_FOUND);
+            OnboardingResponse response = userService.onboard(userId, request);
+
+            assertThat(response.role()).isEqualTo(Role.USER);
+            verify(userProfileRepository).save(any(UserProfile.class));
         }
     }
 
-    private User createUser(Long id, UserStatus status) {
+    private User createUser(Long id, Role role, UserStatus status) {
         return User.builder()
             .id(id)
             .email("hong@example.com")
             .name("홍길동")
-            .role(Role.USER)
+            .role(role)
             .status(status)
             .build();
     }


### PR DESCRIPTION
## 작업 내용

회원 상태관리 전략 변경에 따른 리팩토링
   - `UserStatus`: `ACTIVE`, `INACTIVE`, `WITHDRAWN`
   - `Role`: `GUEST`(온보딩 전), `USER`(온보딩 완료)


## 변경 사항
- 온보딩 완료 시 새 리프레시 토큰과 액세스 토큰 발급
- UserProfile에서 birth 필드 제거

## 체크리스트
- [x] 코드 포맷팅(Checkstyle, Lint 등)을 적용하였는가?
- [x] 테스트 코드를 작성하고 통과했는가?
- [x] 불필요한 console.log / print 등을 제거했는가?
- [x] 로컬 테스트를 완료했는가?
- [x] 관련 서비스 동작을 확인했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 게스트 역할 시스템 도입: 회원가입 시 모든 사용자가 GUEST 역할로 초기 할당
* 온보딩 프로세스 개선: GUEST 사용자가 온보딩 완료 시 USER 역할로 자동 승격 및 새로운 토큰 재발급

## 개선 사항
* 액세스 토큰에 사용자 역할 정보 포함
* 중복 이메일 오류 처리 개선

## 문서
* Swagger API 문서에 보안 요구사항 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->