### PR TITLE
[Feat] 회원 탈퇴 처리 구현

### DIFF
--- a/apps/backend/src/main/java/com/sos/backend/BackendApplication.java
+++ b/apps/backend/src/main/java/com/sos/backend/BackendApplication.java
@@ -3,9 +3,11 @@ package com.sos.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableScheduling
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/repository/AuthProviderRepository.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/repository/AuthProviderRepository.java
@@ -2,6 +2,13 @@ package com.sos.backend.domain.auth.repository;
 
 import com.sos.backend.domain.auth.entity.AuthProvider;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AuthProviderRepository extends JpaRepository<AuthProvider, Long> {
+
+    @Modifying
+    @Query("delete from AuthProvider ap where ap.user.id = :userId")
+    int deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/service/AuthService.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/service/AuthService.java
@@ -71,6 +71,8 @@ public class AuthService {
             User found = existingUser.get();
             if (found.getStatus() == UserStatus.WITHDRAWAL_PENDING) {
                 userWithdrawalService.finalizePendingUserForResignup(found);
+                // 기존 계정 익명화 update를 먼저 DB에 반영해 unique(email) 충돌 방지
+                userRepository.flush();
             } else {
                 throw new CustomException(ErrorCode.EMAIL_ALREADY_EXISTS);
             }

--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/service/AuthService.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/service/AuthService.java
@@ -84,7 +84,6 @@ public class AuthService {
             if (userRepository.existsByEmail(email)) {
                 throw new CustomException(ErrorCode.EMAIL_ALREADY_EXISTS);
             }
-            log.error("회원가입 중 users 저장 실패 - email: {}", email, e);
             throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
 

--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/service/AuthService.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/service/AuthService.java
@@ -16,6 +16,7 @@ import com.sos.backend.domain.user.entity.User;
 import com.sos.backend.domain.user.enums.Role;
 import com.sos.backend.domain.user.enums.UserStatus;
 import com.sos.backend.domain.user.repository.UserRepository;
+import com.sos.backend.domain.user.service.UserWithdrawalService;
 import com.sos.backend.global.auth.JwtProvider;
 import com.sos.backend.global.auth.VerificationTokenProvider;
 import com.sos.backend.global.common.exception.CustomException;
@@ -44,6 +45,7 @@ public class AuthService {
     private final AuthProviderRepository authProviderRepository;
     private final JwtProvider jwtProvider;
     private final RefreshTokenService refreshTokenService;
+    private final UserWithdrawalService userWithdrawalService;
 
     private String dummyHash;
 
@@ -63,9 +65,15 @@ public class AuthService {
         // 2. 비밀번호 길이 검증
         validatePasswordLength(request.password());
 
-        // 3. 이메일 중복 검증
-        if (userRepository.existsByEmail(email)) {
-            throw new CustomException(ErrorCode.EMAIL_ALREADY_EXISTS);
+        // 3. 이메일 중복 검증 (WITHDRAWAL_PENDING이면 즉시 익명화 후 신규 가입 허용)
+        Optional<User> existingUser = userRepository.findByEmail(email);
+        if (existingUser.isPresent()) {
+            User found = existingUser.get();
+            if (found.getStatus() == UserStatus.WITHDRAWAL_PENDING) {
+                userWithdrawalService.finalizePendingUserForResignup(found);
+            } else {
+                throw new CustomException(ErrorCode.EMAIL_ALREADY_EXISTS);
+            }
         }
 
         // 4. User 생성 + 저장

--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/service/EmailVerificationService.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/service/EmailVerificationService.java
@@ -126,4 +126,12 @@ public class EmailVerificationService {
     private String buildDailyKey(String email, VerificationPurpose purpose) {
         return KEY_PREFIX_DAILY + purpose.name() + ":" + email;
     }
+
+    public void deleteVerificationKeysByEmail(String email) {
+        for (VerificationPurpose purpose : VerificationPurpose.values()) {
+            redis.delete(buildCodeKey(email, purpose));
+            redis.delete(buildCooldownKey(email, purpose));
+            redis.delete(buildDailyKey(email, purpose));
+        }
+    }
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/game_session/repository/GameSessionRepository.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/game_session/repository/GameSessionRepository.java
@@ -2,10 +2,16 @@ package com.sos.backend.domain.game_session.repository;
 
 import com.sos.backend.domain.game_session.entity.GameSession;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface GameSessionRepository extends JpaRepository<GameSession, Long> {
     Optional<GameSession> findBySessionId(String sessionId);
+
+    @Modifying
+    @Query("delete from GameSession gs where gs.user.id = :userId")
+    int deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/notification/repository/NotificationRepository.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/notification/repository/NotificationRepository.java
@@ -2,6 +2,13 @@ package com.sos.backend.domain.notification.repository;
 
 import com.sos.backend.domain.notification.entity.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    @Modifying
+    @Query("delete from Notification n where n.user.id = :userId")
+    int deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/scenario_progress/repository/UserScenarioProgressRepository.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/scenario_progress/repository/UserScenarioProgressRepository.java
@@ -2,6 +2,13 @@ package com.sos.backend.domain.scenario_progress.repository;
 
 import com.sos.backend.domain.scenario_progress.entity.UserScenarioProgress;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserScenarioProgressRepository extends JpaRepository<UserScenarioProgress, Long> {
+
+    @Modifying
+    @Query("delete from UserScenarioProgress usp where usp.user.id = :userId")
+    int deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/WithdrawalProperties.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/WithdrawalProperties.java
@@ -1,0 +1,15 @@
+package com.sos.backend.domain.user;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Positive;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@ConfigurationProperties(prefix = "withdrawal")
+@Validated
+public record WithdrawalProperties(
+    @Min(1) int pendingDays,
+    @Positive long schedulerFixedDelayMs,
+    @Positive int schedulerBatchSize
+) {
+}

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/controller/UserController.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/controller/UserController.java
@@ -5,7 +5,9 @@ import com.sos.backend.domain.user.dto.OnboardingResponse;
 import com.sos.backend.domain.user.dto.UserActionResponse;
 import com.sos.backend.domain.user.dto.UserInfoResponse;
 import com.sos.backend.domain.user.dto.UserUpdateRequest;
+import com.sos.backend.domain.user.dto.WithdrawalResponse;
 import com.sos.backend.domain.user.service.UserService;
+import com.sos.backend.domain.user.service.UserWithdrawalService;
 import com.sos.backend.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -23,6 +25,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
+    private final UserWithdrawalService userWithdrawalService;
 
     @GetMapping
     @Operation(summary = "내 정보 조회", description = "현재 사용자(임시: X-User-Id)의 기본 정보를 조회합니다.")
@@ -64,5 +67,21 @@ public class UserController {
         @Valid @RequestBody OnboardingRequest request
     ) {
         return ApiResponse.success(userService.onboard(userId, request));
+    }
+
+    @PostMapping("/withdrawal")
+    @Operation(
+        summary = "회원 탈퇴 요청",
+        description = "계정을 즉시 WITHDRAWAL_PENDING 상태로 전환하고 모든 Refresh Token을 revoke합니다. 최종 익명화/정리는 14일 후 스케줄러가 처리합니다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "탈퇴 요청 접수")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "이미 탈퇴 진행 중이거나 탈퇴된 사용자",
+        content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유저를 찾을 수 없음",
+        content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    public ApiResponse<WithdrawalResponse> requestWithdrawal(
+        @AuthenticationPrincipal Long userId
+    ) {
+        return ApiResponse.success(userWithdrawalService.requestWithdrawal(userId));
     }
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/dto/WithdrawalResponse.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/dto/WithdrawalResponse.java
@@ -1,0 +1,23 @@
+package com.sos.backend.domain.user.dto;
+
+import com.sos.backend.domain.user.enums.UserStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "회원 탈퇴 요청 응답")
+public record WithdrawalResponse(
+    @Schema(description = "처리 결과 메시지", example = "회원 탈퇴가 접수되었습니다.")
+    String message,
+
+    @Schema(description = "최종 익명화 예정 시각", example = "2026-05-20T10:30:00")
+    LocalDateTime scheduledAt,
+
+    @Schema(description = "현재 계정 상태", example = "WITHDRAWAL_PENDING")
+    UserStatus status
+) {
+
+    public static WithdrawalResponse of(LocalDateTime scheduledAt, UserStatus status) {
+        return new WithdrawalResponse("회원 탈퇴가 접수되었습니다.", scheduledAt, status);
+    }
+}

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/entity/User.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/entity/User.java
@@ -57,4 +57,23 @@ public class User extends BaseEntity {
     public void changeRole(Role role) {
         this.role = role;
     }
+
+    public boolean isBlockedForAuthentication() {
+        return this.status == UserStatus.WITHDRAWAL_PENDING || this.status == UserStatus.WITHDRAWN;
+    }
+
+    public void requestWithdrawal() {
+        this.status = UserStatus.WITHDRAWAL_PENDING;
+    }
+
+    public void completeWithdrawal(LocalDateTime now) {
+        if (this.id == null) {
+            throw new IllegalStateException("탈퇴 익명화를 위해 user id가 필요합니다.");
+        }
+        this.email = "withdrawn-" + this.id + "@anonymized.local";
+        this.password = null;
+        this.name = "탈퇴한 사용자";
+        this.status = UserStatus.WITHDRAWN;
+        this.withdrawnAt = now;
+    }
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/entity/User.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/entity/User.java
@@ -58,10 +58,6 @@ public class User extends BaseEntity {
         this.role = role;
     }
 
-    public boolean isBlockedForAuthentication() {
-        return this.status == UserStatus.WITHDRAWAL_PENDING || this.status == UserStatus.WITHDRAWN;
-    }
-
     public void requestWithdrawal() {
         this.status = UserStatus.WITHDRAWAL_PENDING;
     }

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/entity/WithdrawalOutbox.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/entity/WithdrawalOutbox.java
@@ -1,0 +1,70 @@
+package com.sos.backend.domain.user.entity;
+
+import com.sos.backend.domain.user.enums.WithdrawalOutboxStatus;
+import com.sos.backend.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+    name = "withdrawal_outbox",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_withdrawal_outbox_user_id", columnNames = "user_id")
+    },
+    indexes = {
+        @Index(name = "idx_withdrawal_outbox_status_execute_at", columnList = "status,execute_at")
+    }
+)
+public class WithdrawalOutbox extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "withdrawal_outbox_id")
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "execute_at", nullable = false)
+    private LocalDateTime executeAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private WithdrawalOutboxStatus status;
+
+    @Column(name = "processed_at")
+    private LocalDateTime processedAt;
+
+    @Column(name = "last_error", length = 1000)
+    private String lastError;
+
+    public static WithdrawalOutbox schedule(Long userId, LocalDateTime executeAt) {
+        return WithdrawalOutbox.builder()
+            .userId(userId)
+            .executeAt(executeAt)
+            .status(WithdrawalOutboxStatus.PENDING)
+            .build();
+    }
+
+    public void markDone(LocalDateTime now) {
+        this.status = WithdrawalOutboxStatus.DONE;
+        this.processedAt = now;
+        this.lastError = null;
+    }
+
+    public void markFailed(LocalDateTime now, String errorMessage) {
+        this.status = WithdrawalOutboxStatus.PENDING;
+        this.processedAt = null;
+        this.lastError = errorMessage;
+    }
+}

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/entity/WithdrawalOutbox.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/entity/WithdrawalOutbox.java
@@ -63,8 +63,8 @@ public class WithdrawalOutbox extends BaseEntity {
     }
 
     public void markFailed(LocalDateTime now, String errorMessage) {
-        this.status = WithdrawalOutboxStatus.PENDING;
-        this.processedAt = null;
+        this.status = WithdrawalOutboxStatus.FAILED;
+        this.processedAt = now;
         this.lastError = errorMessage;
     }
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/enums/UserStatus.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/enums/UserStatus.java
@@ -1,5 +1,5 @@
 package com.sos.backend.domain.user.enums;
 
 public enum UserStatus {
-    ACTIVE, INACTIVE, WITHDRAWN
+    ACTIVE, INACTIVE, WITHDRAWAL_PENDING, WITHDRAWN
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/enums/WithdrawalOutboxStatus.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/enums/WithdrawalOutboxStatus.java
@@ -1,0 +1,6 @@
+package com.sos.backend.domain.user.enums;
+
+public enum WithdrawalOutboxStatus {
+    PENDING,
+    DONE
+}

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/enums/WithdrawalOutboxStatus.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/enums/WithdrawalOutboxStatus.java
@@ -2,5 +2,6 @@ package com.sos.backend.domain.user.enums;
 
 public enum WithdrawalOutboxStatus {
     PENDING,
-    DONE
+    DONE,
+    FAILED
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/event/UserAnonymizedEvent.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/event/UserAnonymizedEvent.java
@@ -1,0 +1,6 @@
+package com.sos.backend.domain.user.event;
+
+public record UserAnonymizedEvent(
+    String originalEmail
+) {
+}

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/event/UserStatusCacheInvalidateEvent.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/event/UserStatusCacheInvalidateEvent.java
@@ -1,0 +1,6 @@
+package com.sos.backend.domain.user.event;
+
+public record UserStatusCacheInvalidateEvent(
+    Long userId
+) {
+}

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/listener/UserAnonymizedEventListener.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/listener/UserAnonymizedEventListener.java
@@ -1,0 +1,26 @@
+package com.sos.backend.domain.user.listener;
+
+import com.sos.backend.domain.auth.service.EmailVerificationService;
+import com.sos.backend.domain.user.event.UserAnonymizedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserAnonymizedEventListener {
+
+    private final EmailVerificationService emailVerificationService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onUserAnonymized(UserAnonymizedEvent event) {
+        try {
+            emailVerificationService.deleteVerificationKeysByEmail(event.originalEmail());
+        } catch (Exception e) {
+            log.warn("탈퇴 사용자 Redis 인증 키 삭제 실패", e);
+        }
+    }
+}

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/listener/UserStatusCacheEventListener.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/listener/UserStatusCacheEventListener.java
@@ -1,0 +1,20 @@
+package com.sos.backend.domain.user.listener;
+
+import com.sos.backend.domain.user.event.UserStatusCacheInvalidateEvent;
+import com.sos.backend.global.auth.UserStatusCacheService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class UserStatusCacheEventListener {
+
+    private final UserStatusCacheService userStatusCacheService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onUserStatusCacheInvalidate(UserStatusCacheInvalidateEvent event) {
+        userStatusCacheService.invalidate(event.userId());
+    }
+}

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/repository/UserProfileRepository.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/repository/UserProfileRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface UserProfileRepository extends JpaRepository<UserProfile, Long> {
 
     Optional<UserProfile> findByUserId(Long userId);
+
+    void deleteByUserId(Long userId);
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/repository/WithdrawalOutboxRepository.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/repository/WithdrawalOutboxRepository.java
@@ -1,0 +1,26 @@
+package com.sos.backend.domain.user.repository;
+
+import com.sos.backend.domain.user.entity.WithdrawalOutbox;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface WithdrawalOutboxRepository extends JpaRepository<WithdrawalOutbox, Long> {
+
+    Optional<WithdrawalOutbox> findByUserId(Long userId);
+
+    @Query(value = """
+        SELECT *
+        FROM withdrawal_outbox wo
+        WHERE wo.status = 'PENDING'
+          AND wo.execute_at <= :now
+        ORDER BY wo.withdrawal_outbox_id
+        LIMIT 1
+        FOR UPDATE SKIP LOCKED
+        """, nativeQuery = true)
+    Optional<WithdrawalOutbox> lockNextDue(@Param("now") LocalDateTime now);
+
+}

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/scheduler/WithdrawalOutboxScheduler.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/scheduler/WithdrawalOutboxScheduler.java
@@ -1,0 +1,28 @@
+package com.sos.backend.domain.user.scheduler;
+
+import com.sos.backend.domain.user.WithdrawalProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WithdrawalOutboxScheduler {
+
+    private final WithdrawalOutboxWorker withdrawalOutboxWorker;
+    private final WithdrawalProperties withdrawalProperties;
+
+    @Scheduled(fixedDelayString = "${withdrawal.scheduler-fixed-delay-ms}")
+    public void processDueWithdrawals() {
+        for (int i = 0; i < withdrawalProperties.schedulerBatchSize(); i++) {
+            boolean processed = withdrawalOutboxWorker.processOneDue();
+            if (!processed) {
+                return;
+            }
+        }
+
+        log.info("탈퇴 outbox 배치 처리 한도 도달 - batchSize: {}", withdrawalProperties.schedulerBatchSize());
+    }
+}

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/scheduler/WithdrawalOutboxWorker.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/scheduler/WithdrawalOutboxWorker.java
@@ -1,0 +1,46 @@
+package com.sos.backend.domain.user.scheduler;
+
+import com.sos.backend.domain.user.entity.WithdrawalOutbox;
+import com.sos.backend.domain.user.repository.WithdrawalOutboxRepository;
+import com.sos.backend.domain.user.service.UserWithdrawalService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WithdrawalOutboxWorker {
+
+    private final WithdrawalOutboxRepository withdrawalOutboxRepository;
+    private final UserWithdrawalService userWithdrawalService;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public boolean processOneDue() {
+        WithdrawalOutbox outbox = withdrawalOutboxRepository.lockNextDue(LocalDateTime.now())
+            .orElse(null);
+
+        if (outbox == null) {
+            return false;
+        }
+
+        try {
+            userWithdrawalService.finalizeScheduledWithdrawal(outbox);
+        } catch (Exception e) {
+            log.error("탈퇴 outbox 처리 실패 - outboxId: {}, userId: {}", outbox.getId(), outbox.getUserId(), e);
+            outbox.markFailed(LocalDateTime.now(), trimError(e.getMessage()));
+        }
+        return true;
+    }
+
+    private String trimError(String message) {
+        if (message == null) {
+            return "unknown error";
+        }
+        return message.length() <= 1000 ? message : message.substring(0, 1000);
+    }
+}

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/service/UserWithdrawalService.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/service/UserWithdrawalService.java
@@ -1,0 +1,125 @@
+package com.sos.backend.domain.user.service;
+
+import com.sos.backend.domain.auth.repository.AuthProviderRepository;
+import com.sos.backend.domain.auth.service.RefreshTokenService;
+import com.sos.backend.domain.game_session.repository.GameSessionRepository;
+import com.sos.backend.domain.notification.repository.NotificationRepository;
+import com.sos.backend.domain.scenario_progress.repository.UserScenarioProgressRepository;
+import com.sos.backend.domain.user.WithdrawalProperties;
+import com.sos.backend.domain.user.dto.WithdrawalResponse;
+import com.sos.backend.domain.user.entity.User;
+import com.sos.backend.domain.user.entity.WithdrawalOutbox;
+import com.sos.backend.domain.user.enums.UserStatus;
+import com.sos.backend.domain.user.repository.UserProfileRepository;
+import com.sos.backend.domain.user.repository.UserRepository;
+import com.sos.backend.domain.user.repository.WithdrawalOutboxRepository;
+import com.sos.backend.domain.user.event.UserAnonymizedEvent;
+import com.sos.backend.global.auth.UserStatusCacheService;
+import com.sos.backend.global.common.exception.CustomException;
+import com.sos.backend.global.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserWithdrawalService {
+
+    private final UserRepository userRepository;
+    private final UserProfileRepository userProfileRepository;
+    private final AuthProviderRepository authProviderRepository;
+    private final NotificationRepository notificationRepository;
+    private final GameSessionRepository gameSessionRepository;
+    private final UserScenarioProgressRepository userScenarioProgressRepository;
+    private final WithdrawalOutboxRepository withdrawalOutboxRepository;
+    private final RefreshTokenService refreshTokenService;
+    private final UserStatusCacheService userStatusCacheService;
+    private final ApplicationEventPublisher applicationEventPublisher;
+    private final WithdrawalProperties withdrawalProperties;
+
+    @Transactional
+    public WithdrawalResponse requestWithdrawal(Long userId) {
+        User user = getUser(userId);
+
+        if (user.getStatus() == UserStatus.WITHDRAWAL_PENDING || user.getStatus() == UserStatus.WITHDRAWN) {
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+
+        user.requestWithdrawal();
+        refreshTokenService.revokeAllByUserId(userId);
+
+        LocalDateTime executeAt = LocalDateTime.now().plusDays(withdrawalProperties.pendingDays());
+        try {
+            withdrawalOutboxRepository.save(WithdrawalOutbox.schedule(userId, executeAt));
+        } catch (DataIntegrityViolationException e) {
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+
+        userStatusCacheService.invalidate(userId);
+        return WithdrawalResponse.of(executeAt, user.getStatus());
+    }
+
+    @Transactional
+    public void finalizePendingUserForResignup(User user) {
+        if (user.getStatus() != UserStatus.WITHDRAWAL_PENDING) {
+            return;
+        }
+        anonymizeAndCleanup(user, LocalDateTime.now());
+        withdrawalOutboxRepository.findByUserId(user.getId())
+            .ifPresent(outbox -> outbox.markDone(LocalDateTime.now()));
+    }
+
+    @Transactional
+    public void finalizeScheduledWithdrawal(WithdrawalOutbox outbox) {
+        User user = userRepository.findById(outbox.getUserId())
+            .orElse(null);
+
+        if (user == null) {
+            outbox.markDone(LocalDateTime.now());
+            return;
+        }
+
+        if (user.getStatus() == UserStatus.WITHDRAWN) {
+            outbox.markDone(LocalDateTime.now());
+            return;
+        }
+
+        if (user.getStatus() != UserStatus.WITHDRAWAL_PENDING) {
+            log.warn("탈퇴 outbox 처리 건 스킵 - userId: {}, status: {}", user.getId(), user.getStatus());
+            outbox.markDone(LocalDateTime.now());
+            return;
+        }
+
+        anonymizeAndCleanup(user, LocalDateTime.now());
+        outbox.markDone(LocalDateTime.now());
+    }
+
+    private void anonymizeAndCleanup(User user, LocalDateTime now) {
+        String originalEmail = user.getEmail();
+
+        userProfileRepository.deleteByUserId(user.getId());
+        authProviderRepository.deleteAllByUserId(user.getId());
+        notificationRepository.deleteAllByUserId(user.getId());
+        gameSessionRepository.deleteAllByUserId(user.getId());
+        userScenarioProgressRepository.deleteAllByUserId(user.getId());
+        refreshTokenService.revokeAllByUserId(user.getId());
+
+        // TODO: game-engine(Mongo) cleanup 엔드포인트 연동은 추후 작업에서 추가한다.
+        user.completeWithdrawal(now);
+        userStatusCacheService.invalidate(user.getId());
+
+        applicationEventPublisher.publishEvent(new UserAnonymizedEvent(originalEmail));
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/service/UserWithdrawalService.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/service/UserWithdrawalService.java
@@ -14,6 +14,7 @@ import com.sos.backend.domain.user.repository.UserProfileRepository;
 import com.sos.backend.domain.user.repository.UserRepository;
 import com.sos.backend.domain.user.repository.WithdrawalOutboxRepository;
 import com.sos.backend.domain.user.event.UserAnonymizedEvent;
+import com.sos.backend.domain.user.event.UserStatusCacheInvalidateEvent;
 import com.sos.backend.global.auth.UserStatusCacheService;
 import com.sos.backend.global.common.exception.CustomException;
 import com.sos.backend.global.common.exception.ErrorCode;
@@ -62,7 +63,8 @@ public class UserWithdrawalService {
             throw new CustomException(ErrorCode.INVALID_INPUT);
         }
 
-        userStatusCacheService.invalidate(userId);
+        userStatusCacheService.cacheStatus(userId, UserStatus.WITHDRAWAL_PENDING);
+        applicationEventPublisher.publishEvent(new UserStatusCacheInvalidateEvent(userId));
         return WithdrawalResponse.of(executeAt, user.getStatus());
     }
 

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/service/UserWithdrawalService.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/service/UserWithdrawalService.java
@@ -48,7 +48,7 @@ public class UserWithdrawalService {
     public WithdrawalResponse requestWithdrawal(Long userId) {
         User user = getUser(userId);
 
-        if (user.getStatus() == UserStatus.WITHDRAWAL_PENDING || user.getStatus() == UserStatus.WITHDRAWN) {
+        if (user.getStatus() != UserStatus.ACTIVE) {
             throw new CustomException(ErrorCode.INVALID_INPUT);
         }
 

--- a/apps/backend/src/main/java/com/sos/backend/global/auth/JwtFilter.java
+++ b/apps/backend/src/main/java/com/sos/backend/global/auth/JwtFilter.java
@@ -1,5 +1,6 @@
 package com.sos.backend.global.auth;
 
+import com.sos.backend.domain.user.enums.UserStatus;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -16,6 +17,7 @@ import java.util.Collections;
 public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
+    private final UserStatusCacheService userStatusCacheService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -28,6 +30,12 @@ public class JwtFilter extends OncePerRequestFilter {
         if (token != null && jwtProvider.validateToken(token)) {
             Long userId = jwtProvider.getUserId(token);
             String email = jwtProvider.getEmail(token);
+            UserStatus userStatus = userStatusCacheService.getStatus(userId);
+
+            if (userStatus == UserStatus.WITHDRAWAL_PENDING || userStatus == UserStatus.WITHDRAWN) {
+                filterChain.doFilter(request, response);
+                return;
+            }
 
             UsernamePasswordAuthenticationToken authentication =
                 new UsernamePasswordAuthenticationToken(

--- a/apps/backend/src/main/java/com/sos/backend/global/auth/UserStatusCacheService.java
+++ b/apps/backend/src/main/java/com/sos/backend/global/auth/UserStatusCacheService.java
@@ -1,0 +1,49 @@
+package com.sos.backend.global.auth;
+
+import com.sos.backend.domain.user.entity.User;
+import com.sos.backend.domain.user.enums.UserStatus;
+import com.sos.backend.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class UserStatusCacheService {
+
+    private static final long TTL_MILLIS = 60_000L;
+
+    private final UserRepository userRepository;
+    private final Map<Long, CacheEntry> cache = new ConcurrentHashMap<>();
+
+    public UserStatusCacheService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public UserStatus getStatus(Long userId) {
+        long now = System.currentTimeMillis();
+        CacheEntry cached = cache.get(userId);
+        if (cached != null && cached.expiresAtMillis() > now) {
+            return cached.status();
+        }
+
+        UserStatus loaded = userRepository.findById(userId)
+            .map(User::getStatus)
+            .orElse(null);
+
+        if (loaded == null) {
+            cache.remove(userId);
+            return null;
+        }
+
+        cache.put(userId, new CacheEntry(loaded, now + TTL_MILLIS));
+        return loaded;
+    }
+
+    public void invalidate(Long userId) {
+        cache.remove(userId);
+    }
+
+    private record CacheEntry(UserStatus status, long expiresAtMillis) {
+    }
+}

--- a/apps/backend/src/main/java/com/sos/backend/global/auth/UserStatusCacheService.java
+++ b/apps/backend/src/main/java/com/sos/backend/global/auth/UserStatusCacheService.java
@@ -44,6 +44,11 @@ public class UserStatusCacheService {
         cache.remove(userId);
     }
 
+    public void cacheStatus(Long userId, UserStatus status) {
+        long now = System.currentTimeMillis();
+        cache.put(userId, new CacheEntry(status, now + TTL_MILLIS));
+    }
+
     private record CacheEntry(UserStatus status, long expiresAtMillis) {
     }
 }

--- a/apps/backend/src/main/java/com/sos/backend/global/common/config/SecurityConfig.java
+++ b/apps/backend/src/main/java/com/sos/backend/global/common/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.sos.backend.global.common.config;
 import com.sos.backend.domain.auth.PasswordProperties;
 import com.sos.backend.global.auth.JwtFilter;
 import com.sos.backend.global.auth.JwtProvider;
+import com.sos.backend.global.auth.UserStatusCacheService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,6 +16,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import jakarta.servlet.http.HttpServletResponse;
+
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
@@ -22,6 +25,7 @@ public class SecurityConfig {
 
     private final JwtProvider jwtProvider;
     private final PasswordProperties passwordProperties;
+    private final UserStatusCacheService userStatusCacheService;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -48,7 +52,11 @@ public class SecurityConfig {
                 ).permitAll()
                 .anyRequest().authenticated()
             )
-            .addFilterBefore(new JwtFilter(jwtProvider),
+            .exceptionHandling(ex -> ex
+                .authenticationEntryPoint((request, response, authException) ->
+                    response.sendError(HttpServletResponse.SC_UNAUTHORIZED))
+            )
+            .addFilterBefore(new JwtFilter(jwtProvider, userStatusCacheService),
                 UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/apps/backend/src/main/resources/application.yml
+++ b/apps/backend/src/main/resources/application.yml
@@ -31,6 +31,11 @@ auth:
     max-length: 72             # BCrypt 입력 byte 한계
     bcrypt-strength: 12
 
+withdrawal:
+  pending-days: 14
+  scheduler-fixed-delay-ms: 30000
+  scheduler-batch-size: 20
+
 mail:
   sender:
     from: noreply@safeorscam.com

--- a/apps/backend/src/test/java/com/sos/backend/domain/auth/service/AuthServiceTest.java
+++ b/apps/backend/src/test/java/com/sos/backend/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,95 @@
+package com.sos.backend.domain.auth.service;
+
+import com.sos.backend.domain.auth.PasswordProperties;
+import com.sos.backend.domain.auth.dto.request.SignupRequest;
+import com.sos.backend.domain.auth.dto.response.SignupResponse;
+import com.sos.backend.domain.auth.entity.AuthProvider;
+import com.sos.backend.domain.auth.enums.VerificationPurpose;
+import com.sos.backend.domain.auth.repository.AuthProviderRepository;
+import com.sos.backend.domain.user.entity.User;
+import com.sos.backend.domain.user.enums.Role;
+import com.sos.backend.domain.user.enums.UserStatus;
+import com.sos.backend.domain.user.repository.UserRepository;
+import com.sos.backend.domain.user.service.UserWithdrawalService;
+import com.sos.backend.global.auth.JwtProvider;
+import com.sos.backend.global.auth.VerificationTokenProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private VerificationTokenProvider verificationTokenProvider;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private AuthProviderRepository authProviderRepository;
+    @Mock
+    private JwtProvider jwtProvider;
+    @Mock
+    private RefreshTokenService refreshTokenService;
+    @Mock
+    private UserWithdrawalService userWithdrawalService;
+
+    @Test
+    @DisplayName("회원가입 시 기존 PENDING 계정을 즉시 익명화하면 flush 후 신규 가입을 진행한다")
+    void signup_flushesAfterFinalizingPendingUser() {
+        PasswordProperties passwordProperties = new PasswordProperties(10, 72, 12);
+        AuthService authService = new AuthService(
+            verificationTokenProvider,
+            passwordEncoder,
+            passwordProperties,
+            userRepository,
+            authProviderRepository,
+            jwtProvider,
+            refreshTokenService,
+            userWithdrawalService
+        );
+
+        String email = "resignup@sos.com";
+        SignupRequest request = new SignupRequest("verification-token", "1234567890", "홍길동");
+        User pendingUser = User.builder()
+            .id(99L)
+            .email(email)
+            .name("기존유저")
+            .role(Role.USER)
+            .status(UserStatus.WITHDRAWAL_PENDING)
+            .build();
+
+        given(verificationTokenProvider.validateAndGetEmail("verification-token", VerificationPurpose.SIGNUP))
+            .willReturn(email);
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(pendingUser));
+        given(passwordEncoder.encode("1234567890")).willReturn("encoded-password");
+        given(jwtProvider.createAccessToken(any(), anyString(), any())).willReturn("new-access-token");
+        given(refreshTokenService.issue(any(User.class))).willReturn("new-refresh-token");
+        given(authProviderRepository.save(any(AuthProvider.class))).willReturn(null);
+
+        SignupResponse response = authService.signup(request);
+
+        InOrder inOrder = inOrder(userWithdrawalService, userRepository);
+        inOrder.verify(userWithdrawalService).finalizePendingUserForResignup(pendingUser);
+        inOrder.verify(userRepository).flush();
+        inOrder.verify(userRepository).save(any(User.class));
+
+        assertThat(response.accessToken()).isEqualTo("new-access-token");
+        assertThat(response.refreshToken()).isEqualTo("new-refresh-token");
+        verify(authProviderRepository).save(any(AuthProvider.class));
+    }
+}

--- a/apps/backend/src/test/java/com/sos/backend/domain/user/entity/WithdrawalOutboxTest.java
+++ b/apps/backend/src/test/java/com/sos/backend/domain/user/entity/WithdrawalOutboxTest.java
@@ -1,0 +1,25 @@
+package com.sos.backend.domain.user.entity;
+
+import com.sos.backend.domain.user.enums.WithdrawalOutboxStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WithdrawalOutboxTest {
+
+    @Test
+    @DisplayName("처리 실패 시 상태를 FAILED로 전환하고 processedAt을 기록한다")
+    void markFailed_changesStatusToFailed() {
+        WithdrawalOutbox outbox = WithdrawalOutbox.schedule(1L, LocalDateTime.now().plusDays(14));
+        LocalDateTime now = LocalDateTime.now();
+
+        outbox.markFailed(now, "boom");
+
+        assertThat(outbox.getStatus()).isEqualTo(WithdrawalOutboxStatus.FAILED);
+        assertThat(outbox.getProcessedAt()).isEqualTo(now);
+        assertThat(outbox.getLastError()).isEqualTo("boom");
+    }
+}

--- a/apps/backend/src/test/java/com/sos/backend/domain/user/service/UserWithdrawalServiceTest.java
+++ b/apps/backend/src/test/java/com/sos/backend/domain/user/service/UserWithdrawalServiceTest.java
@@ -11,6 +11,7 @@ import com.sos.backend.domain.user.entity.User;
 import com.sos.backend.domain.user.entity.WithdrawalOutbox;
 import com.sos.backend.domain.user.enums.Role;
 import com.sos.backend.domain.user.enums.UserStatus;
+import com.sos.backend.domain.user.enums.WithdrawalOutboxStatus;
 import com.sos.backend.domain.user.event.UserAnonymizedEvent;
 import com.sos.backend.domain.user.repository.UserProfileRepository;
 import com.sos.backend.domain.user.repository.UserRepository;
@@ -129,6 +130,8 @@ class UserWithdrawalServiceTest {
         when(withdrawalOutboxRepository.findByUserId(userId)).thenReturn(Optional.of(outbox));
 
         userWithdrawalService.finalizePendingUserForResignup(user);
+        assertThat(outbox.getStatus()).isEqualTo(WithdrawalOutboxStatus.DONE);
+        assertThat(outbox.getProcessedAt()).isNotNull();
 
         assertThat(user.getStatus()).isEqualTo(UserStatus.WITHDRAWN);
         assertThat(user.getEmail()).isEqualTo("withdrawn-3@anonymized.local");

--- a/apps/backend/src/test/java/com/sos/backend/domain/user/service/UserWithdrawalServiceTest.java
+++ b/apps/backend/src/test/java/com/sos/backend/domain/user/service/UserWithdrawalServiceTest.java
@@ -13,6 +13,7 @@ import com.sos.backend.domain.user.enums.Role;
 import com.sos.backend.domain.user.enums.UserStatus;
 import com.sos.backend.domain.user.enums.WithdrawalOutboxStatus;
 import com.sos.backend.domain.user.event.UserAnonymizedEvent;
+import com.sos.backend.domain.user.event.UserStatusCacheInvalidateEvent;
 import com.sos.backend.domain.user.repository.UserProfileRepository;
 import com.sos.backend.domain.user.repository.UserRepository;
 import com.sos.backend.domain.user.repository.WithdrawalOutboxRepository;
@@ -103,7 +104,8 @@ class UserWithdrawalServiceTest {
             assertThat(outboxCaptor.getValue().getUserId()).isEqualTo(userId);
 
             verify(refreshTokenService).revokeAllByUserId(userId);
-            verify(userStatusCacheService).invalidate(userId);
+            verify(userStatusCacheService).cacheStatus(userId, UserStatus.WITHDRAWAL_PENDING);
+            verify(applicationEventPublisher).publishEvent(any(UserStatusCacheInvalidateEvent.class));
         }
 
         @Test

--- a/apps/backend/src/test/java/com/sos/backend/domain/user/service/UserWithdrawalServiceTest.java
+++ b/apps/backend/src/test/java/com/sos/backend/domain/user/service/UserWithdrawalServiceTest.java
@@ -1,0 +1,158 @@
+package com.sos.backend.domain.user.service;
+
+import com.sos.backend.domain.auth.repository.AuthProviderRepository;
+import com.sos.backend.domain.auth.service.RefreshTokenService;
+import com.sos.backend.domain.game_session.repository.GameSessionRepository;
+import com.sos.backend.domain.notification.repository.NotificationRepository;
+import com.sos.backend.domain.scenario_progress.repository.UserScenarioProgressRepository;
+import com.sos.backend.domain.user.WithdrawalProperties;
+import com.sos.backend.domain.user.dto.WithdrawalResponse;
+import com.sos.backend.domain.user.entity.User;
+import com.sos.backend.domain.user.entity.WithdrawalOutbox;
+import com.sos.backend.domain.user.enums.Role;
+import com.sos.backend.domain.user.enums.UserStatus;
+import com.sos.backend.domain.user.event.UserAnonymizedEvent;
+import com.sos.backend.domain.user.repository.UserProfileRepository;
+import com.sos.backend.domain.user.repository.UserRepository;
+import com.sos.backend.domain.user.repository.WithdrawalOutboxRepository;
+import com.sos.backend.global.auth.UserStatusCacheService;
+import com.sos.backend.global.common.exception.CustomException;
+import com.sos.backend.global.common.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserWithdrawalServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private UserProfileRepository userProfileRepository;
+    @Mock
+    private AuthProviderRepository authProviderRepository;
+    @Mock
+    private NotificationRepository notificationRepository;
+    @Mock
+    private GameSessionRepository gameSessionRepository;
+    @Mock
+    private UserScenarioProgressRepository userScenarioProgressRepository;
+    @Mock
+    private WithdrawalOutboxRepository withdrawalOutboxRepository;
+    @Mock
+    private RefreshTokenService refreshTokenService;
+    @Mock
+    private UserStatusCacheService userStatusCacheService;
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
+
+    private UserWithdrawalService userWithdrawalService;
+
+    @BeforeEach
+    void setUp() {
+        WithdrawalProperties properties = new WithdrawalProperties(14, 30_000L, 20);
+        userWithdrawalService = new UserWithdrawalService(
+            userRepository,
+            userProfileRepository,
+            authProviderRepository,
+            notificationRepository,
+            gameSessionRepository,
+            userScenarioProgressRepository,
+            withdrawalOutboxRepository,
+            refreshTokenService,
+            userStatusCacheService,
+            applicationEventPublisher,
+            properties
+        );
+    }
+
+    @Nested
+    @DisplayName("회원 탈퇴 요청")
+    class RequestWithdrawal {
+
+        @Test
+        @DisplayName("ACTIVE 사용자는 WITHDRAWAL_PENDING으로 전환되고 outbox가 생성된다")
+        void requestWithdrawal_success() {
+            Long userId = 1L;
+            User user = createUser(userId, "user@sos.com", UserStatus.ACTIVE);
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+            WithdrawalResponse response = userWithdrawalService.requestWithdrawal(userId);
+
+            assertThat(response.status()).isEqualTo(UserStatus.WITHDRAWAL_PENDING);
+            assertThat(user.getStatus()).isEqualTo(UserStatus.WITHDRAWAL_PENDING);
+
+            ArgumentCaptor<WithdrawalOutbox> outboxCaptor = ArgumentCaptor.forClass(WithdrawalOutbox.class);
+            verify(withdrawalOutboxRepository).save(outboxCaptor.capture());
+            assertThat(outboxCaptor.getValue().getUserId()).isEqualTo(userId);
+
+            verify(refreshTokenService).revokeAllByUserId(userId);
+            verify(userStatusCacheService).invalidate(userId);
+        }
+
+        @Test
+        @DisplayName("이미 WITHDRAWAL_PENDING이면 INVALID_INPUT 예외를 던진다")
+        void requestWithdrawal_pendingUser() {
+            Long userId = 1L;
+            User user = createUser(userId, "user@sos.com", UserStatus.WITHDRAWAL_PENDING);
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+            assertThatThrownBy(() -> userWithdrawalService.requestWithdrawal(userId))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_INPUT);
+        }
+    }
+
+    @Test
+    @DisplayName("재가입 시 PENDING 사용자를 즉시 익명화한다")
+    void finalizePendingUserForResignup_success() {
+        Long userId = 3L;
+        User user = createUser(userId, "pending@sos.com", UserStatus.WITHDRAWAL_PENDING);
+        WithdrawalOutbox outbox = WithdrawalOutbox.schedule(userId, LocalDateTime.now().plusDays(14));
+
+        when(withdrawalOutboxRepository.findByUserId(userId)).thenReturn(Optional.of(outbox));
+
+        userWithdrawalService.finalizePendingUserForResignup(user);
+
+        assertThat(user.getStatus()).isEqualTo(UserStatus.WITHDRAWN);
+        assertThat(user.getEmail()).isEqualTo("withdrawn-3@anonymized.local");
+        assertThat(user.getPassword()).isNull();
+        assertThat(user.getName()).isEqualTo("탈퇴한 사용자");
+
+        verify(userProfileRepository).deleteByUserId(userId);
+        verify(authProviderRepository).deleteAllByUserId(userId);
+        verify(notificationRepository).deleteAllByUserId(userId);
+        verify(gameSessionRepository).deleteAllByUserId(userId);
+        verify(userScenarioProgressRepository).deleteAllByUserId(userId);
+        verify(refreshTokenService).revokeAllByUserId(userId);
+        verify(userStatusCacheService).invalidate(userId);
+        verify(applicationEventPublisher).publishEvent(any(UserAnonymizedEvent.class));
+    }
+
+    private User createUser(Long id, String email, UserStatus status) {
+        return User.builder()
+            .id(id)
+            .email(email)
+            .password("encoded")
+            .name("테스트")
+            .role(Role.USER)
+            .status(status)
+            .build();
+    }
+}


### PR DESCRIPTION
## 관련 이슈
Closes #23 

## 작업 내용
1. 회원 탈퇴 api 구현

## 변경 사항
1. 
2. markFailed가 status를 다시 PENDING으로 유지하여 starvation이 발생하는 문제
3. 탈퇴 직후 인증 우회(상태 캐시 레이스) 해결
- 탈퇴 요청 트랜잭션 안에서 캐시에 WITHDRAWAL_PENDING 강제 반영
- 커밋 후(AFTER_COMMIT) 이벤트 리스너에서 캐시 invalidate
 

## 체크리스트
- [ ] 코드 포맷팅(Checkstyle, Lint 등)을 적용하였는가?
- [ ] 테스트 코드를 작성하고 통과했는가?
- [ ] 불필요한 console.log / print 등을 제거했는가?
- [ ] 로컬 테스트를 완료했는가?
- [ ] 관련 서비스 동작을 확인했는가?