### PR TITLE
[Feat] (front) signup, login, and email verification API 연동 구현

### DIFF
--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -1,2 +1,3 @@
-VITE_API_URL=http://localhost:8080
-VITE_GAME_ENGINE_URL=http://localhost:8000
+# Local development uses Vite proxy, so keep these blank for relative API paths.
+VITE_API_URL=
+VITE_GAME_ENGINE_URL=

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -20,6 +20,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@tailwindcss/vite": "^4.2.4",
+        "@tanstack/react-query-devtools": "^5.100.9",
         "@types/node": "^24.12.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -1157,6 +1158,17 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.100.9.tgz",
+      "integrity": "sha512-gqiptrTIhbK2PuCaPRHmWXfJG1NGYVFpAr0HqogEqiSBNB5xDz6fmesQt7w4WgMOqOQPnPHJ3ZDMuhDaXvNO8g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tanstack/react-query": {
       "version": "5.100.9",
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.9.tgz",
@@ -1170,6 +1182,24 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.100.9.tgz",
+      "integrity": "sha512-mM3slaVGXJmz+pOLgXdANj75ikgQCyudyl3kmFvm6brI1JyVeY/+IeD17uDHIvZrD8hfoO2sdZ54RFsHdYAuhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.100.9"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.100.9",
         "react": "^18 || ^19"
       }
     },

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@tailwindcss/vite": "^4.2.4",
+    "@tanstack/react-query-devtools": "^5.100.9",
     "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import { Link, Navigate, Route, Routes } from 'react-router-dom'
 
-import { useLogout } from '@/features/auth/hooks'
+import { useAuthBootstrap, useLogout } from '@/features/auth/hooks'
 import { LoginPage } from '@/features/auth/pages/LoginPage'
 import { SignupPage } from '@/features/auth/pages/SignupPage'
 import { EmailVerificationPage } from '@/features/auth/pages/EmailVerificationPage'
@@ -12,6 +12,8 @@ import { LandingPage } from '@/pages/LandingPage'
 import { ProtectedRoute } from '@/routes/ProtectedRoute'
 
 function App() {
+  useAuthBootstrap()
+
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
   const logoutMutation = useLogout()
 

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,34 +1,55 @@
 import { Link, Navigate, Route, Routes } from 'react-router-dom'
 
+import { useLogout } from '@/features/auth/hooks'
 import { LoginPage } from '@/features/auth/pages/LoginPage'
 import { SignupPage } from '@/features/auth/pages/SignupPage'
 import { EmailVerificationPage } from '@/features/auth/pages/EmailVerificationPage'
+import { useAuthStore } from '@/features/auth/store'
 import { LobbyPage } from '@/features/game-session/pages/LobbyPage'
 import { MyPage } from '@/features/user/pages/MyPage'
 import { OnboardingPage } from '@/features/user/pages/OnboardingPage'
 import { LandingPage } from '@/pages/LandingPage'
+import { ProtectedRoute } from '@/routes/ProtectedRoute'
 
 function App() {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
+  const logoutMutation = useLogout()
+
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
       <header className="border-b border-white/10 bg-slate-950/90">
         <nav className="mx-auto flex w-full max-w-6xl items-center justify-between px-5 py-4">
-          <Link to="/" className="text-lg font-semibold tracking-normal">
+          <Link to={isAuthenticated ? '/lobby' : '/'} className="text-lg font-semibold tracking-normal">
             Safe or Scam
           </Link>
           <div className="flex items-center gap-4 text-sm text-slate-300">
-            <Link to="/login" className="hover:text-white">
-              로그인
-            </Link>
-            <Link to="/signup" className="hover:text-white">
-              회원가입
-            </Link>
-            <Link to="/lobby" className="hover:text-white">
-              로비
-            </Link>
-            <Link to="/mypage" className="hover:text-white">
-              마이페이지
-            </Link>
+            {isAuthenticated ? (
+              <>
+                <Link to="/lobby" className="hover:text-white">
+                  로비
+                </Link>
+                <Link to="/mypage" className="hover:text-white">
+                  마이페이지
+                </Link>
+                <button
+                  type="button"
+                  disabled={logoutMutation.isPending}
+                  onClick={() => logoutMutation.mutate()}
+                  className="rounded-md border border-white/10 px-3 py-1.5 text-slate-200 hover:border-emerald-300 hover:text-white disabled:cursor-not-allowed disabled:text-slate-500"
+                >
+                  {logoutMutation.isPending ? '로그아웃 중...' : '로그아웃'}
+                </button>
+              </>
+            ) : (
+              <>
+                <Link to="/login" className="hover:text-white">
+                  로그인
+                </Link>
+                <Link to="/signup" className="hover:text-white">
+                  회원가입
+                </Link>
+              </>
+            )}
           </div>
         </nav>
       </header>
@@ -39,9 +60,30 @@ function App() {
           <Route path="/login" element={<LoginPage />} />
           <Route path="/signup" element={<SignupPage />} />
           <Route path="/signup/verify" element={<EmailVerificationPage />} />
-          <Route path="/onboarding" element={<OnboardingPage />} />
-          <Route path="/lobby" element={<LobbyPage />} />
-          <Route path="/mypage" element={<MyPage />} />
+          <Route
+            path="/onboarding"
+            element={
+              <ProtectedRoute>
+                <OnboardingPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/lobby"
+            element={
+              <ProtectedRoute>
+                <LobbyPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/mypage"
+            element={
+              <ProtectedRoute>
+                <MyPage />
+              </ProtectedRoute>
+            }
+          />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </main>

--- a/apps/frontend/src/features/auth/api.ts
+++ b/apps/frontend/src/features/auth/api.ts
@@ -1,4 +1,4 @@
-import type { AxiosResponse } from 'axios'
+import type { AxiosRequestConfig, AxiosResponse } from 'axios'
 
 import { apiClient } from '@/shared/api/client'
 
@@ -9,6 +9,8 @@ import type {
   EmailVerifyResponse,
   LoginRequest,
   LoginResponse,
+  LogoutRequest,
+  MeResponse,
   SignupRequest,
   SignupResponse,
 } from './types'
@@ -35,8 +37,12 @@ export const authApi = {
     const response = await apiClient.post<ApiResponse<LoginResponse>>('/api/v1/auth/login', request)
     return unwrapData(response)
   },
-  logout: async () => {
-    const response = await apiClient.post<ApiResponse<null>>('/api/v1/auth/logout/all')
+  getMe: async (config?: AxiosRequestConfig) => {
+    const response = await apiClient.get<ApiResponse<MeResponse>>('/api/v1/users/me', config)
+    return unwrapData(response)
+  },
+  logout: async (request: LogoutRequest) => {
+    const response = await apiClient.post<ApiResponse<null>>('/api/v1/auth/logout', request)
     return unwrapData(response)
   },
 }

--- a/apps/frontend/src/features/auth/api.ts
+++ b/apps/frontend/src/features/auth/api.ts
@@ -1,0 +1,42 @@
+import type { AxiosResponse } from 'axios'
+
+import { apiClient } from '@/shared/api/client'
+
+import type {
+  ApiResponse,
+  EmailSendRequest,
+  EmailVerifyRequest,
+  EmailVerifyResponse,
+  LoginRequest,
+  LoginResponse,
+  SignupRequest,
+  SignupResponse,
+} from './types'
+
+const unwrapData = <T>(response: AxiosResponse<ApiResponse<T>>) => response.data.data
+
+export const authApi = {
+  sendVerificationEmail: async (request: EmailSendRequest) => {
+    const response = await apiClient.post<ApiResponse<null>>('/api/v1/auth/email/send', request)
+    return unwrapData(response)
+  },
+  verifyEmail: async (request: EmailVerifyRequest) => {
+    const response = await apiClient.post<ApiResponse<EmailVerifyResponse>>(
+      '/api/v1/auth/email/verify',
+      request,
+    )
+    return unwrapData(response)
+  },
+  signup: async (request: SignupRequest) => {
+    const response = await apiClient.post<ApiResponse<SignupResponse>>('/api/v1/auth/signup', request)
+    return unwrapData(response)
+  },
+  login: async (request: LoginRequest) => {
+    const response = await apiClient.post<ApiResponse<LoginResponse>>('/api/v1/auth/login', request)
+    return unwrapData(response)
+  },
+  logout: async () => {
+    const response = await apiClient.post<ApiResponse<null>>('/api/v1/auth/logout/all')
+    return unwrapData(response)
+  },
+}

--- a/apps/frontend/src/features/auth/hooks.ts
+++ b/apps/frontend/src/features/auth/hooks.ts
@@ -1,4 +1,5 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useEffect } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useLocation, useNavigate, type Location } from 'react-router-dom'
 
 import { authApi } from './api'
@@ -9,7 +10,7 @@ import type {
   AuthUser,
   EmailVerifyRequest,
   LoginResponse,
-  SignupDraft,
+  MeResponse,
   SignupResponse,
   SignupRequest,
 } from './types'
@@ -32,6 +33,11 @@ const normalizeSignupUser = (user: SignupResponse['user']): AuthUser => ({
   role: user.role,
 })
 
+const normalizeMeUser = (user: MeResponse): AuthUser => ({
+  email: user.email,
+  name: user.name,
+})
+
 const getRedirectPath = (state: unknown) => {
   const redirectState = state as RedirectState | null
   const from = redirectState?.from
@@ -43,9 +49,40 @@ const getRedirectPath = (state: unknown) => {
   return `${from.pathname}${from.search}${from.hash}`
 }
 
+export const useAuthBootstrap = () => {
+  const accessToken = useAuthStore((state) => state.accessToken)
+  const user = useAuthStore((state) => state.user)
+  const setUser = useAuthStore((state) => state.setUser)
+  const clearAuth = useAuthStore((state) => state.clearAuth)
+
+  const meQuery = useQuery({
+    queryKey: authKeys.user(),
+    queryFn: ({ signal }) => authApi.getMe({ signal }),
+    enabled: Boolean(accessToken && !user),
+    retry: false,
+  })
+
+  useEffect(() => {
+    if (meQuery.data) {
+      setUser(normalizeMeUser(meQuery.data))
+    }
+  }, [meQuery.data, setUser])
+
+  useEffect(() => {
+    if (meQuery.error) {
+      clearAuth()
+    }
+  }, [clearAuth, meQuery.error])
+
+  return {
+    isLoadingUser: Boolean(accessToken && !user && meQuery.isPending),
+  }
+}
+
 export const useSendSignupVerificationEmail = () => {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
+  const setSignupDraft = useAuthStore((state) => state.setSignupDraft)
 
   return useMutation({
     mutationFn: (values: SignupFormValues) =>
@@ -57,13 +94,12 @@ export const useSendSignupVerificationEmail = () => {
       void queryClient.invalidateQueries({
         queryKey: authKeys.emailVerification(values.email),
       })
-      navigate('/signup/verify', {
-        state: {
-          email: values.email,
-          name: values.name,
-          password: values.password,
-        } satisfies SignupDraft,
+      setSignupDraft({
+        email: values.email,
+        name: values.name,
+        password: values.password,
       })
+      navigate('/signup/verify')
     },
   })
 }
@@ -85,11 +121,13 @@ export const useSignup = () => {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const setAuth = useAuthStore((state) => state.setAuth)
+  const clearSignupDraft = useAuthStore((state) => state.clearSignupDraft)
 
   return useMutation({
     mutationFn: (request: SignupRequest) => authApi.signup(request),
     onSuccess: (response) => {
-      setAuth(response.accessToken, normalizeSignupUser(response.user))
+      setAuth(response.accessToken, response.refreshToken, normalizeSignupUser(response.user))
+      clearSignupDraft()
       void queryClient.invalidateQueries({ queryKey: authKeys.session() })
       navigate('/onboarding', { replace: true })
     },
@@ -105,7 +143,7 @@ export const useLogin = () => {
   return useMutation({
     mutationFn: authApi.login,
     onSuccess: (response) => {
-      setAuth(response.accessToken, normalizeLoginUser(response.user))
+      setAuth(response.accessToken, response.refreshToken, normalizeLoginUser(response.user))
       void queryClient.invalidateQueries({ queryKey: authKeys.session() })
       navigate(getRedirectPath(location.state), { replace: true })
     },
@@ -116,9 +154,11 @@ export const useLogout = () => {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const clearAuth = useAuthStore((state) => state.clearAuth)
+  const refreshToken = useAuthStore((state) => state.refreshToken)
 
   return useMutation({
-    mutationFn: authApi.logout,
+    mutationFn: () =>
+      refreshToken ? authApi.logout({ refreshToken }) : Promise.resolve(null),
     onSettled: () => {
       clearAuth()
       void queryClient.invalidateQueries({ queryKey: authKeys.session() })

--- a/apps/frontend/src/features/auth/hooks.ts
+++ b/apps/frontend/src/features/auth/hooks.ts
@@ -1,0 +1,128 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useLocation, useNavigate, type Location } from 'react-router-dom'
+
+import { authApi } from './api'
+import { authKeys } from './queryKeys'
+import type { SignupFormValues } from './schemas'
+import { useAuthStore } from './store'
+import type {
+  AuthUser,
+  EmailVerifyRequest,
+  LoginResponse,
+  SignupDraft,
+  SignupResponse,
+  SignupRequest,
+} from './types'
+
+type RedirectState = {
+  from?: Pick<Location, 'pathname' | 'search' | 'hash'>
+}
+
+const normalizeLoginUser = (user: LoginResponse['user']): AuthUser => ({
+  id: user.id,
+  email: user.email,
+  name: user.name,
+  role: user.role,
+})
+
+const normalizeSignupUser = (user: SignupResponse['user']): AuthUser => ({
+  id: user.userId,
+  email: user.email,
+  name: user.name,
+  role: user.role,
+})
+
+const getRedirectPath = (state: unknown) => {
+  const redirectState = state as RedirectState | null
+  const from = redirectState?.from
+
+  if (!from) {
+    return '/lobby'
+  }
+
+  return `${from.pathname}${from.search}${from.hash}`
+}
+
+export const useSendSignupVerificationEmail = () => {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (values: SignupFormValues) =>
+      authApi.sendVerificationEmail({
+        email: values.email,
+        purpose: 'SIGNUP',
+      }),
+    onSuccess: (_data, values) => {
+      void queryClient.invalidateQueries({
+        queryKey: authKeys.emailVerification(values.email),
+      })
+      navigate('/signup/verify', {
+        state: {
+          email: values.email,
+          name: values.name,
+          password: values.password,
+        } satisfies SignupDraft,
+      })
+    },
+  })
+}
+
+export const useVerifyEmail = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (request: EmailVerifyRequest) => authApi.verifyEmail(request),
+    onSuccess: (_data, request) => {
+      void queryClient.invalidateQueries({
+        queryKey: authKeys.emailVerification(request.email),
+      })
+    },
+  })
+}
+
+export const useSignup = () => {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const setAuth = useAuthStore((state) => state.setAuth)
+
+  return useMutation({
+    mutationFn: (request: SignupRequest) => authApi.signup(request),
+    onSuccess: (response) => {
+      setAuth(response.accessToken, normalizeSignupUser(response.user))
+      void queryClient.invalidateQueries({ queryKey: authKeys.session() })
+      navigate('/onboarding', { replace: true })
+    },
+  })
+}
+
+export const useLogin = () => {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const setAuth = useAuthStore((state) => state.setAuth)
+
+  return useMutation({
+    mutationFn: authApi.login,
+    onSuccess: (response) => {
+      setAuth(response.accessToken, normalizeLoginUser(response.user))
+      void queryClient.invalidateQueries({ queryKey: authKeys.session() })
+      navigate(getRedirectPath(location.state), { replace: true })
+    },
+  })
+}
+
+export const useLogout = () => {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const clearAuth = useAuthStore((state) => state.clearAuth)
+
+  return useMutation({
+    mutationFn: authApi.logout,
+    onSettled: () => {
+      clearAuth()
+      void queryClient.invalidateQueries({ queryKey: authKeys.session() })
+      navigate('/login', { replace: true })
+    },
+  })
+}

--- a/apps/frontend/src/features/auth/pages/EmailVerificationPage.tsx
+++ b/apps/frontend/src/features/auth/pages/EmailVerificationPage.tsx
@@ -1,6 +1,92 @@
-import { Link } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
+import { useForm } from 'react-hook-form'
+
+import { toApiError } from '@/shared/api/error'
+
+import { useSignup, useVerifyEmail } from '../hooks'
+import {
+  emailVerificationSchema,
+  type EmailVerificationFormValues,
+} from '../schemas'
+import type { SignupDraft } from '../types'
+
+const isSignupDraft = (value: unknown): value is SignupDraft => {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  const draft = value as Record<string, unknown>
+  return (
+    typeof draft.email === 'string' &&
+    typeof draft.name === 'string' &&
+    typeof draft.password === 'string'
+  )
+}
 
 export function EmailVerificationPage() {
+  const location = useLocation()
+  const signupDraft = isSignupDraft(location.state) ? location.state : null
+  const verifyEmailMutation = useVerifyEmail()
+  const signupMutation = useSignup()
+  const {
+    clearErrors,
+    formState: { errors },
+    handleSubmit,
+    register,
+    setError,
+  } = useForm<EmailVerificationFormValues>({
+    defaultValues: {
+      code: '',
+    },
+  })
+
+  const pending = verifyEmailMutation.isPending || signupMutation.isPending
+  const serverError = verifyEmailMutation.error
+    ? toApiError(verifyEmailMutation.error)
+    : signupMutation.error
+      ? toApiError(signupMutation.error)
+      : null
+
+  const onSubmit = (values: EmailVerificationFormValues) => {
+    if (!signupDraft) {
+      return
+    }
+
+    clearErrors()
+    const validation = emailVerificationSchema.safeParse(values)
+
+    if (!validation.success) {
+      validation.error.issues.forEach((issue) => {
+        const field = issue.path[0]
+
+        if (field === 'code') {
+          setError(field, {
+            type: 'zod',
+            message: issue.message,
+          })
+        }
+      })
+      return
+    }
+
+    verifyEmailMutation.mutate(
+      {
+        email: signupDraft.email,
+        code: validation.data.code,
+        purpose: 'SIGNUP',
+      },
+      {
+        onSuccess: ({ verificationToken }) => {
+          signupMutation.mutate({
+            verificationToken,
+            password: signupDraft.password,
+            name: signupDraft.name,
+          })
+        },
+      },
+    )
+  }
+
   return (
     <section className="mx-auto max-w-md space-y-6 py-10">
       <div className="space-y-2">
@@ -8,7 +94,17 @@ export function EmailVerificationPage() {
         <p className="text-slate-300">이메일로 받은 6자리 인증 코드를 입력하세요.</p>
       </div>
 
-      <form className="space-y-5 rounded-lg border border-white/10 bg-white/[0.03] p-6">
+      <form className="space-y-5 rounded-lg border border-white/10 bg-white/[0.03] p-6" onSubmit={handleSubmit(onSubmit)}>
+        {!signupDraft ? (
+          <div className="rounded-md border border-amber-300/30 bg-amber-300/10 px-3 py-2 text-sm text-amber-100">
+            회원가입 정보를 찾을 수 없습니다. 다시 가입 정보를 입력해주세요.
+          </div>
+        ) : null}
+        {serverError ? (
+          <div className="whitespace-pre-line rounded-md border border-red-400/30 bg-red-500/10 px-3 py-2 text-sm text-red-100">
+            {serverError.message}
+          </div>
+        ) : null}
         <label className="block space-y-2">
           <span className="text-sm font-medium text-slate-200">인증 코드</span>
           <input
@@ -16,16 +112,30 @@ export function EmailVerificationPage() {
             inputMode="numeric"
             maxLength={6}
             placeholder="000000"
-            className="w-full rounded-md border border-white/10 bg-slate-900 px-3 py-3 text-center text-2xl font-semibold tracking-normal text-white outline-none focus:border-emerald-300"
+            autoComplete="one-time-code"
+            aria-invalid={Boolean(errors.code)}
+            disabled={!signupDraft || pending}
+            className="w-full rounded-md border border-white/10 bg-slate-900 px-3 py-3 text-center text-2xl font-semibold tracking-normal text-white outline-none focus:border-emerald-300 disabled:cursor-not-allowed disabled:bg-slate-800 disabled:text-slate-500"
+            {...register('code')}
           />
+          {errors.code?.message ? <p className="text-sm text-red-200">{errors.code.message}</p> : null}
         </label>
-        <Link
-          to="/onboarding"
-          className="block w-full rounded-md bg-emerald-400 px-4 py-3 text-center font-semibold text-slate-950 hover:bg-emerald-300"
+        <button
+          type="submit"
+          disabled={!signupDraft || pending}
+          className="block w-full rounded-md bg-emerald-400 px-4 py-3 text-center font-semibold text-slate-950 hover:bg-emerald-300 disabled:cursor-not-allowed disabled:bg-slate-600 disabled:text-slate-300"
         >
-          인증 완료
-        </Link>
+          {pending ? '확인 중...' : '인증 완료'}
+        </button>
       </form>
+
+      {!signupDraft ? (
+        <p className="text-sm text-slate-400">
+          <Link to="/signup" className="font-medium text-emerald-300">
+            회원가입으로 돌아가기
+          </Link>
+        </p>
+      ) : null}
     </section>
   )
 }

--- a/apps/frontend/src/features/auth/pages/EmailVerificationPage.tsx
+++ b/apps/frontend/src/features/auth/pages/EmailVerificationPage.tsx
@@ -1,4 +1,5 @@
-import { Link, useLocation } from 'react-router-dom'
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
 import { useForm } from 'react-hook-form'
 
 import { toApiError } from '@/shared/api/error'
@@ -8,24 +9,11 @@ import {
   emailVerificationSchema,
   type EmailVerificationFormValues,
 } from '../schemas'
-import type { SignupDraft } from '../types'
-
-const isSignupDraft = (value: unknown): value is SignupDraft => {
-  if (typeof value !== 'object' || value === null) {
-    return false
-  }
-
-  const draft = value as Record<string, unknown>
-  return (
-    typeof draft.email === 'string' &&
-    typeof draft.name === 'string' &&
-    typeof draft.password === 'string'
-  )
-}
+import { useAuthStore } from '../store'
 
 export function EmailVerificationPage() {
-  const location = useLocation()
-  const signupDraft = isSignupDraft(location.state) ? location.state : null
+  const signupDraft = useAuthStore((state) => state.signupDraft)
+  const [verificationToken, setVerificationToken] = useState<string | null>(null)
   const verifyEmailMutation = useVerifyEmail()
   const signupMutation = useSignup()
   const {
@@ -49,6 +37,15 @@ export function EmailVerificationPage() {
 
   const onSubmit = (values: EmailVerificationFormValues) => {
     if (!signupDraft) {
+      return
+    }
+
+    if (verificationToken) {
+      signupMutation.mutate({
+        verificationToken,
+        password: signupDraft.password,
+        name: signupDraft.name,
+      })
       return
     }
 
@@ -76,9 +73,10 @@ export function EmailVerificationPage() {
         purpose: 'SIGNUP',
       },
       {
-        onSuccess: ({ verificationToken }) => {
+        onSuccess: ({ verificationToken: nextVerificationToken }) => {
+          setVerificationToken(nextVerificationToken)
           signupMutation.mutate({
-            verificationToken,
+            verificationToken: nextVerificationToken,
             password: signupDraft.password,
             name: signupDraft.name,
           })

--- a/apps/frontend/src/features/auth/pages/EmailVerificationPage.tsx
+++ b/apps/frontend/src/features/auth/pages/EmailVerificationPage.tsx
@@ -92,7 +92,7 @@ export function EmailVerificationPage() {
         <p className="text-slate-300">이메일로 받은 6자리 인증 코드를 입력하세요.</p>
       </div>
 
-      <form className="space-y-5 rounded-lg border border-white/10 bg-white/[0.03] p-6" onSubmit={handleSubmit(onSubmit)}>
+      <form className="space-y-5 rounded-lg border border-white/10 bg-white/3 p-6" onSubmit={handleSubmit(onSubmit)}>
         {!signupDraft ? (
           <div className="rounded-md border border-amber-300/30 bg-amber-300/10 px-3 py-2 text-sm text-amber-100">
             회원가입 정보를 찾을 수 없습니다. 다시 가입 정보를 입력해주세요.

--- a/apps/frontend/src/features/auth/pages/LoginPage.tsx
+++ b/apps/frontend/src/features/auth/pages/LoginPage.tsx
@@ -51,7 +51,7 @@ export function LoginPage() {
         <p className="text-slate-300">학습 기록과 맞춤 시나리오를 이어서 확인합니다.</p>
       </div>
 
-      <form className="space-y-4 rounded-lg border border-white/10 bg-white/[0.03] p-6" onSubmit={handleSubmit(onSubmit)}>
+      <form className="space-y-4 rounded-lg border border-white/10 bg-white/3 p-6" onSubmit={handleSubmit(onSubmit)}>
         {serverError ? (
           <div className="whitespace-pre-line rounded-md border border-red-400/30 bg-red-500/10 px-3 py-2 text-sm text-red-100">
             {serverError.message}

--- a/apps/frontend/src/features/auth/pages/LoginPage.tsx
+++ b/apps/frontend/src/features/auth/pages/LoginPage.tsx
@@ -1,6 +1,49 @@
 import { Link } from 'react-router-dom'
+import { useForm } from 'react-hook-form'
+
+import { toApiError } from '@/shared/api/error'
+
+import { useLogin } from '../hooks'
+import { loginSchema, type LoginFormValues } from '../schemas'
 
 export function LoginPage() {
+  const loginMutation = useLogin()
+  const {
+    clearErrors,
+    formState: { errors },
+    handleSubmit,
+    register,
+    setError,
+  } = useForm<LoginFormValues>({
+    defaultValues: {
+      email: '',
+      password: '',
+    },
+  })
+
+  const serverError = loginMutation.error ? toApiError(loginMutation.error) : null
+
+  const onSubmit = (values: LoginFormValues) => {
+    clearErrors()
+    const validation = loginSchema.safeParse(values)
+
+    if (!validation.success) {
+      validation.error.issues.forEach((issue) => {
+        const field = issue.path[0]
+
+        if (field === 'email' || field === 'password') {
+          setError(field, {
+            type: 'zod',
+            message: issue.message,
+          })
+        }
+      })
+      return
+    }
+
+    loginMutation.mutate(validation.data)
+  }
+
   return (
     <section className="mx-auto max-w-md space-y-6 py-10">
       <div className="space-y-2">
@@ -8,28 +51,42 @@ export function LoginPage() {
         <p className="text-slate-300">학습 기록과 맞춤 시나리오를 이어서 확인합니다.</p>
       </div>
 
-      <form className="space-y-4 rounded-lg border border-white/10 bg-white/[0.03] p-6">
+      <form className="space-y-4 rounded-lg border border-white/10 bg-white/[0.03] p-6" onSubmit={handleSubmit(onSubmit)}>
+        {serverError ? (
+          <div className="whitespace-pre-line rounded-md border border-red-400/30 bg-red-500/10 px-3 py-2 text-sm text-red-100">
+            {serverError.message}
+          </div>
+        ) : null}
         <label className="block space-y-2">
           <span className="text-sm font-medium text-slate-200">이메일</span>
           <input
             type="email"
             placeholder="sos@example.com"
+            autoComplete="email"
+            aria-invalid={Boolean(errors.email)}
             className="w-full rounded-md border border-white/10 bg-slate-900 px-3 py-3 text-white outline-none focus:border-emerald-300"
+            {...register('email')}
           />
+          {errors.email?.message ? <p className="text-sm text-red-200">{errors.email.message}</p> : null}
         </label>
         <label className="block space-y-2">
           <span className="text-sm font-medium text-slate-200">비밀번호</span>
           <input
             type="password"
             placeholder="비밀번호"
+            autoComplete="current-password"
+            aria-invalid={Boolean(errors.password)}
             className="w-full rounded-md border border-white/10 bg-slate-900 px-3 py-3 text-white outline-none focus:border-emerald-300"
+            {...register('password')}
           />
+          {errors.password?.message ? <p className="text-sm text-red-200">{errors.password.message}</p> : null}
         </label>
         <button
-          type="button"
-          className="w-full rounded-md bg-emerald-400 px-4 py-3 font-semibold text-slate-950 hover:bg-emerald-300"
+          type="submit"
+          disabled={loginMutation.isPending}
+          className="w-full rounded-md bg-emerald-400 px-4 py-3 font-semibold text-slate-950 hover:bg-emerald-300 disabled:cursor-not-allowed disabled:bg-slate-600 disabled:text-slate-300"
         >
-          로그인
+          {loginMutation.isPending ? '로그인 중...' : '로그인'}
         </button>
       </form>
 

--- a/apps/frontend/src/features/auth/pages/SignupPage.tsx
+++ b/apps/frontend/src/features/auth/pages/SignupPage.tsx
@@ -54,7 +54,7 @@ export function SignupPage() {
         <p className="text-slate-300">피싱 대응 훈련을 위한 기본 계정을 만듭니다.</p>
       </div>
 
-      <form className="space-y-4 rounded-lg border border-white/10 bg-white/[0.03] p-6" onSubmit={handleSubmit(onSubmit)}>
+      <form className="space-y-4 rounded-lg border border-white/10 bg-white/3 p-6" onSubmit={handleSubmit(onSubmit)}>
         {serverError ? (
           <div className="whitespace-pre-line rounded-md border border-red-400/30 bg-red-500/10 px-3 py-2 text-sm text-red-100">
             {serverError.message}

--- a/apps/frontend/src/features/auth/pages/SignupPage.tsx
+++ b/apps/frontend/src/features/auth/pages/SignupPage.tsx
@@ -1,6 +1,52 @@
 import { Link } from 'react-router-dom'
+import { useForm } from 'react-hook-form'
+
+import { toApiError } from '@/shared/api/error'
+
+import { useSendSignupVerificationEmail } from '../hooks'
+import { signupSchema, type SignupFormValues } from '../schemas'
 
 export function SignupPage() {
+  const sendVerificationMutation = useSendSignupVerificationEmail()
+  const {
+    clearErrors,
+    formState: { errors },
+    handleSubmit,
+    register,
+    setError,
+  } = useForm<SignupFormValues>({
+    defaultValues: {
+      name: '',
+      email: '',
+      password: '',
+    },
+  })
+
+  const serverError = sendVerificationMutation.error
+    ? toApiError(sendVerificationMutation.error)
+    : null
+
+  const onSubmit = (values: SignupFormValues) => {
+    clearErrors()
+    const validation = signupSchema.safeParse(values)
+
+    if (!validation.success) {
+      validation.error.issues.forEach((issue) => {
+        const field = issue.path[0]
+
+        if (field === 'name' || field === 'email' || field === 'password') {
+          setError(field, {
+            type: 'zod',
+            message: issue.message,
+          })
+        }
+      })
+      return
+    }
+
+    sendVerificationMutation.mutate(validation.data)
+  }
+
   return (
     <section className="mx-auto max-w-md space-y-6 py-10">
       <div className="space-y-2">
@@ -8,37 +54,55 @@ export function SignupPage() {
         <p className="text-slate-300">피싱 대응 훈련을 위한 기본 계정을 만듭니다.</p>
       </div>
 
-      <form className="space-y-4 rounded-lg border border-white/10 bg-white/[0.03] p-6">
+      <form className="space-y-4 rounded-lg border border-white/10 bg-white/[0.03] p-6" onSubmit={handleSubmit(onSubmit)}>
+        {serverError ? (
+          <div className="whitespace-pre-line rounded-md border border-red-400/30 bg-red-500/10 px-3 py-2 text-sm text-red-100">
+            {serverError.message}
+          </div>
+        ) : null}
         <label className="block space-y-2">
           <span className="text-sm font-medium text-slate-200">이름</span>
           <input
             type="text"
             placeholder="홍길동"
+            autoComplete="name"
+            aria-invalid={Boolean(errors.name)}
             className="w-full rounded-md border border-white/10 bg-slate-900 px-3 py-3 text-white outline-none focus:border-emerald-300"
+            {...register('name')}
           />
+          {errors.name?.message ? <p className="text-sm text-red-200">{errors.name.message}</p> : null}
         </label>
         <label className="block space-y-2">
           <span className="text-sm font-medium text-slate-200">이메일</span>
           <input
             type="email"
             placeholder="sos@example.com"
+            autoComplete="email"
+            aria-invalid={Boolean(errors.email)}
             className="w-full rounded-md border border-white/10 bg-slate-900 px-3 py-3 text-white outline-none focus:border-emerald-300"
+            {...register('email')}
           />
+          {errors.email?.message ? <p className="text-sm text-red-200">{errors.email.message}</p> : null}
         </label>
         <label className="block space-y-2">
           <span className="text-sm font-medium text-slate-200">비밀번호</span>
           <input
             type="password"
-            placeholder="8자 이상"
+            placeholder="10자 이상"
+            autoComplete="new-password"
+            aria-invalid={Boolean(errors.password)}
             className="w-full rounded-md border border-white/10 bg-slate-900 px-3 py-3 text-white outline-none focus:border-emerald-300"
+            {...register('password')}
           />
+          {errors.password?.message ? <p className="text-sm text-red-200">{errors.password.message}</p> : null}
         </label>
-        <Link
-          to="/signup/verify"
-          className="block w-full rounded-md bg-emerald-400 px-4 py-3 text-center font-semibold text-slate-950 hover:bg-emerald-300"
+        <button
+          type="submit"
+          disabled={sendVerificationMutation.isPending}
+          className="block w-full rounded-md bg-emerald-400 px-4 py-3 text-center font-semibold text-slate-950 hover:bg-emerald-300 disabled:cursor-not-allowed disabled:bg-slate-600 disabled:text-slate-300"
         >
-          인증 메일 받기
-        </Link>
+          {sendVerificationMutation.isPending ? '발송 중...' : '인증 메일 받기'}
+        </button>
       </form>
 
       <p className="text-sm text-slate-400">

--- a/apps/frontend/src/features/auth/queryKeys.ts
+++ b/apps/frontend/src/features/auth/queryKeys.ts
@@ -1,0 +1,6 @@
+export const authKeys = {
+  all: ['auth'] as const,
+  session: () => [...authKeys.all, 'session'] as const,
+  user: () => [...authKeys.session(), 'user'] as const,
+  emailVerification: (email: string) => [...authKeys.all, 'email-verification', email] as const,
+}

--- a/apps/frontend/src/features/auth/schemas.ts
+++ b/apps/frontend/src/features/auth/schemas.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod'
+
+const EMAIL_REQUIRED_MESSAGE = '이메일을 입력해주세요'
+const EMAIL_INVALID_MESSAGE = '이메일 형식이 올바르지 않습니다'
+const PASSWORD_REQUIRED_MESSAGE = '비밀번호를 입력해주세요'
+
+const passwordByteLength = (password: string) => new TextEncoder().encode(password).length
+
+export const loginSchema = z.object({
+  email: z.string().trim().min(1, EMAIL_REQUIRED_MESSAGE).email(EMAIL_INVALID_MESSAGE),
+  password: z.string().min(1, PASSWORD_REQUIRED_MESSAGE),
+})
+
+export const signupSchema = z.object({
+  name: z.string().trim().min(1, '이름을 입력해주세요'),
+  email: z.string().trim().min(1, EMAIL_REQUIRED_MESSAGE).email(EMAIL_INVALID_MESSAGE),
+  password: z
+    .string()
+    .min(1, PASSWORD_REQUIRED_MESSAGE)
+    .min(10, '비밀번호는 10자 이상이어야 합니다')
+    .refine((password) => passwordByteLength(password) <= 72, {
+      message: '비밀번호는 72바이트 이하여야 합니다',
+    }),
+})
+
+export const emailVerificationSchema = z.object({
+  code: z.string().regex(/^\d{6}$/, '인증 코드는 6자리 숫자여야 합니다'),
+})
+
+export type LoginFormValues = z.infer<typeof loginSchema>
+export type SignupFormValues = z.infer<typeof signupSchema>
+export type EmailVerificationFormValues = z.infer<typeof emailVerificationSchema>

--- a/apps/frontend/src/features/auth/store.ts
+++ b/apps/frontend/src/features/auth/store.ts
@@ -1,13 +1,19 @@
 import { create } from 'zustand'
 
-import type { AuthUser } from './types'
+import type { AuthUser, SignupDraft } from './types'
 
 type AuthState = {
   accessToken: string | null
+  // Intentionally memory-only for current-session logout; refresh rotation belongs to the Day 3 auth flow.
+  refreshToken: string | null
   user: AuthUser | null
+  signupDraft: SignupDraft | null
   isAuthenticated: boolean
-  setAuth: (accessToken: string, user: AuthUser) => void
+  setAuth: (accessToken: string, refreshToken: string, user: AuthUser) => void
+  setUser: (user: AuthUser) => void
   clearAuth: () => void
+  setSignupDraft: (signupDraft: SignupDraft) => void
+  clearSignupDraft: () => void
 }
 
 const getInitialAccessToken = () => {
@@ -15,6 +21,7 @@ const getInitialAccessToken = () => {
     return null
   }
 
+  // TODO: Move session persistence to HttpOnly cookies or a BFF once the backend auth contract supports it.
   return localStorage.getItem('accessToken')
 }
 
@@ -23,23 +30,36 @@ export const useAuthStore = create<AuthState>((set) => {
 
   return {
     accessToken,
+    refreshToken: null,
     user: null,
+    signupDraft: null,
     isAuthenticated: Boolean(accessToken),
-    setAuth: (nextAccessToken, user) => {
+    setAuth: (nextAccessToken, nextRefreshToken, user) => {
       localStorage.setItem('accessToken', nextAccessToken)
       set({
         accessToken: nextAccessToken,
+        refreshToken: nextRefreshToken,
         user,
         isAuthenticated: true,
       })
+    },
+    setUser: (user) => {
+      set({ user })
     },
     clearAuth: () => {
       localStorage.removeItem('accessToken')
       set({
         accessToken: null,
+        refreshToken: null,
         user: null,
         isAuthenticated: false,
       })
+    },
+    setSignupDraft: (signupDraft) => {
+      set({ signupDraft })
+    },
+    clearSignupDraft: () => {
+      set({ signupDraft: null })
     },
   }
 })

--- a/apps/frontend/src/features/auth/store.ts
+++ b/apps/frontend/src/features/auth/store.ts
@@ -1,0 +1,45 @@
+import { create } from 'zustand'
+
+import type { AuthUser } from './types'
+
+type AuthState = {
+  accessToken: string | null
+  user: AuthUser | null
+  isAuthenticated: boolean
+  setAuth: (accessToken: string, user: AuthUser) => void
+  clearAuth: () => void
+}
+
+const getInitialAccessToken = () => {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  return localStorage.getItem('accessToken')
+}
+
+export const useAuthStore = create<AuthState>((set) => {
+  const accessToken = getInitialAccessToken()
+
+  return {
+    accessToken,
+    user: null,
+    isAuthenticated: Boolean(accessToken),
+    setAuth: (nextAccessToken, user) => {
+      localStorage.setItem('accessToken', nextAccessToken)
+      set({
+        accessToken: nextAccessToken,
+        user,
+        isAuthenticated: true,
+      })
+    },
+    clearAuth: () => {
+      localStorage.removeItem('accessToken')
+      set({
+        accessToken: null,
+        user: null,
+        isAuthenticated: false,
+      })
+    },
+  }
+})

--- a/apps/frontend/src/features/auth/types.ts
+++ b/apps/frontend/src/features/auth/types.ts
@@ -1,0 +1,79 @@
+export type VerificationPurpose = 'SIGNUP' | 'RESET_PASSWORD'
+
+export type UserRole = 'GUEST' | 'USER' | 'ADMIN'
+
+export type LoginRequest = {
+  email: string
+  password: string
+}
+
+export type EmailSendRequest = {
+  email: string
+  purpose: VerificationPurpose
+}
+
+export type EmailVerifyRequest = {
+  email: string
+  code: string
+  purpose: VerificationPurpose
+}
+
+export type SignupRequest = {
+  verificationToken: string
+  password: string
+  name: string
+}
+
+export type LoginResponse = {
+  accessToken: string
+  refreshToken: string
+  user: {
+    id: number
+    email: string
+    name: string
+    role: UserRole
+  }
+}
+
+export type SignupResponse = {
+  accessToken: string
+  refreshToken: string
+  user: {
+    userId: number
+    email: string
+    name: string
+    role: UserRole
+  }
+}
+
+export type EmailVerifyResponse = {
+  verificationToken: string
+}
+
+export type ApiResponse<T> = {
+  data: T
+  error?: {
+    code: string
+    message: string
+    fieldInfo?: {
+      field: string
+      message: string
+    }[]
+  } | null
+  meta: {
+    timestamp: string
+  }
+}
+
+export type AuthUser = {
+  id: number
+  email: string
+  name: string
+  role: UserRole
+}
+
+export type SignupDraft = {
+  email: string
+  name: string
+  password: string
+}

--- a/apps/frontend/src/features/auth/types.ts
+++ b/apps/frontend/src/features/auth/types.ts
@@ -24,6 +24,10 @@ export type SignupRequest = {
   name: string
 }
 
+export type LogoutRequest = {
+  refreshToken: string
+}
+
 export type LoginResponse = {
   accessToken: string
   refreshToken: string
@@ -50,6 +54,14 @@ export type EmailVerifyResponse = {
   verificationToken: string
 }
 
+export type MeResponse = {
+  name: string
+  email: string
+  occupation: string | null
+  gender: string | null
+  ageGroup: string | null
+}
+
 export type ApiResponse<T> = {
   data: T
   error?: {
@@ -66,10 +78,10 @@ export type ApiResponse<T> = {
 }
 
 export type AuthUser = {
-  id: number
+  id?: number
   email: string
   name: string
-  role: UserRole
+  role?: UserRole
 }
 
 export type SignupDraft = {

--- a/apps/frontend/src/features/game-session/pages/LobbyPage.tsx
+++ b/apps/frontend/src/features/game-session/pages/LobbyPage.tsx
@@ -30,7 +30,7 @@ export function LobbyPage() {
         <h2 className="text-xl font-semibold text-white">전체 시나리오</h2>
         <div className="grid gap-4 md:grid-cols-3">
           {scenarios.map((scenario) => (
-            <article key={scenario.title} className="rounded-lg border border-white/10 bg-white/[0.03] p-5">
+            <article key={scenario.title} className="rounded-lg border border-white/10 bg-white/3 p-5">
               <div className="flex items-center justify-between gap-3">
                 <span className="rounded-md bg-slate-800 px-2 py-1 text-xs text-slate-300">{scenario.difficulty}</span>
                 <span className="text-xs font-medium text-emerald-300">{scenario.status}</span>

--- a/apps/frontend/src/features/user/pages/MyPage.tsx
+++ b/apps/frontend/src/features/user/pages/MyPage.tsx
@@ -34,7 +34,7 @@ export function MyPage() {
         <p className="text-slate-300">가입 정보는 조회만 가능하며, 온보딩 답변만 수정할 수 있습니다.</p>
       </div>
 
-      <section className="space-y-4 rounded-lg border border-white/10 bg-white/[0.03] p-6">
+      <section className="space-y-4 rounded-lg border border-white/10 bg-white/3 p-6">
         <h2 className="text-lg font-semibold text-white">회원 정보</h2>
         <div className="grid gap-4 sm:grid-cols-2">
           <div className="rounded-md border border-white/10 bg-slate-900 px-3 py-3">
@@ -48,7 +48,7 @@ export function MyPage() {
         </div>
       </section>
 
-      <form className="space-y-5 rounded-lg border border-white/10 bg-white/[0.03] p-6">
+      <form className="space-y-5 rounded-lg border border-white/10 bg-white/3 p-6">
         <h2 className="text-lg font-semibold text-white">온보딩 답변</h2>
 
         <label className="block space-y-2">
@@ -101,7 +101,7 @@ export function MyPage() {
         </button>
       </form>
 
-      <section className="space-y-4 rounded-lg border border-white/10 bg-white/[0.03] p-6">
+      <section className="space-y-4 rounded-lg border border-white/10 bg-white/3 p-6">
         <div className="space-y-1">
           <h2 className="text-lg font-semibold text-white">히스토리</h2>
           <p className="text-sm text-slate-400">

--- a/apps/frontend/src/features/user/pages/OnboardingPage.tsx
+++ b/apps/frontend/src/features/user/pages/OnboardingPage.tsx
@@ -12,7 +12,7 @@ export function OnboardingPage() {
         <p className="text-slate-300">직업, 연령대, 성별을 선택하면 맞춤 훈련 추천에 활용됩니다.</p>
       </div>
 
-      <div className="space-y-5 rounded-lg border border-white/10 bg-white/[0.03] p-6">
+      <div className="space-y-5 rounded-lg border border-white/10 bg-white/3 p-6">
         <div className="space-y-3">
           <h2 className="text-base font-semibold text-white">직업</h2>
           <div className="grid gap-2 sm:grid-cols-4">

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import App from './App'
 import './index.css'
 
@@ -22,6 +23,7 @@ createRoot(document.getElementById('root')!).render(
       <BrowserRouter>
         <App />
       </BrowserRouter>
+      <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   </StrictMode>,
 )

--- a/apps/frontend/src/pages/LandingPage.tsx
+++ b/apps/frontend/src/pages/LandingPage.tsx
@@ -30,7 +30,7 @@ export function LandingPage() {
         </div>
       </div>
 
-      <div className="rounded-lg border border-white/10 bg-white/[0.03] p-5">
+      <div className="rounded-lg border border-white/10 bg-white/3 p-5">
         <div className="space-y-4">
           <div className="rounded-md border border-amber-300/30 bg-amber-300/10 p-4 text-left">
             <p className="text-sm font-semibold text-amber-200">문자 메시지</p>

--- a/apps/frontend/src/routes/ProtectedRoute.tsx
+++ b/apps/frontend/src/routes/ProtectedRoute.tsx
@@ -1,15 +1,17 @@
 import type { ReactNode } from 'react'
 import { Navigate, useLocation } from 'react-router-dom'
 
+import { useAuthStore } from '@/features/auth/store'
+
 type ProtectedRouteProps = {
   children: ReactNode
 }
 
 export function ProtectedRoute({ children }: ProtectedRouteProps) {
   const location = useLocation()
-  const accessToken = localStorage.getItem('accessToken')
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
 
-  if (!accessToken) {
+  if (!isAuthenticated) {
     return <Navigate to="/login" replace state={{ from: location }} />
   }
 

--- a/apps/frontend/src/routes/ProtectedRoute.tsx
+++ b/apps/frontend/src/routes/ProtectedRoute.tsx
@@ -10,9 +10,18 @@ type ProtectedRouteProps = {
 export function ProtectedRoute({ children }: ProtectedRouteProps) {
   const location = useLocation()
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
+  const user = useAuthStore((state) => state.user)
 
   if (!isAuthenticated) {
     return <Navigate to="/login" replace state={{ from: location }} />
+  }
+
+  if (!user) {
+    return (
+      <div className="py-16 text-center text-sm text-slate-300">
+        인증 상태를 확인하고 있습니다.
+      </div>
+    )
   }
 
   return children

--- a/apps/frontend/src/shared/api/error.ts
+++ b/apps/frontend/src/shared/api/error.ts
@@ -1,0 +1,67 @@
+import axios from 'axios'
+
+type BackendFieldError = {
+  field: string
+  message: string
+}
+
+type BackendErrorInfo = {
+  code?: string
+  message?: string
+  fieldInfo?: BackendFieldError[]
+}
+
+type BackendErrorResponse = {
+  error?: BackendErrorInfo | null
+}
+
+export type ApiError = {
+  status?: number
+  code?: string
+  message: string
+}
+
+const DEFAULT_ERROR_MESSAGE = '요청 처리 중 문제가 발생했습니다'
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+const isBackendErrorResponse = (value: unknown): value is BackendErrorResponse => {
+  if (!isRecord(value)) {
+    return false
+  }
+
+  const error = value.error
+  return error === null || error === undefined || isRecord(error)
+}
+
+export const toApiError = (error: unknown): ApiError => {
+  if (!axios.isAxiosError(error)) {
+    return {
+      message: error instanceof Error ? error.message : DEFAULT_ERROR_MESSAGE,
+    }
+  }
+
+  const status = error.response?.status
+  const payload = error.response?.data
+
+  if (!isBackendErrorResponse(payload) || !payload.error) {
+    return {
+      status,
+      message: error.message || DEFAULT_ERROR_MESSAGE,
+    }
+  }
+
+  const fieldMessages = payload.error.fieldInfo?.map(
+    (fieldError) => `${fieldError.field}: ${fieldError.message}`,
+  )
+
+  return {
+    status,
+    code: payload.error.code,
+    message:
+      fieldMessages && fieldMessages.length > 0
+        ? fieldMessages.join('\n')
+        : payload.error.message || DEFAULT_ERROR_MESSAGE,
+  }
+}

--- a/apps/frontend/src/shared/api/error.ts
+++ b/apps/frontend/src/shared/api/error.ts
@@ -38,7 +38,7 @@ const isBackendErrorResponse = (value: unknown): value is BackendErrorResponse =
 export const toApiError = (error: unknown): ApiError => {
   if (!axios.isAxiosError(error)) {
     return {
-      message: error instanceof Error ? error.message : DEFAULT_ERROR_MESSAGE,
+      message: DEFAULT_ERROR_MESSAGE,
     }
   }
 
@@ -48,7 +48,7 @@ export const toApiError = (error: unknown): ApiError => {
   if (!isBackendErrorResponse(payload) || !payload.error) {
     return {
       status,
-      message: error.message || DEFAULT_ERROR_MESSAGE,
+      message: DEFAULT_ERROR_MESSAGE,
     }
   }
 

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -11,4 +11,16 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
+      '/game-api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
## 관련 이슈
Closes #33 

## 작업 내용
프론트엔드 인증 흐름을 백엔드 API와 연동하고, 로그인 상태에 따른 라우팅/헤더 분기를 적용했습니다. 
이메일 인증 기반 회원가입, 이메일+비밀번호 로그인, 로그아웃, 보호 라우트 접근 제어, 새로고침 후 토큰 기반 로그인 상태 유지가 동작하도록 구성했습니다.

## 변경 사항
- auth 도메인 파일 추가: types, schemas, api, store, hooks, queryKeys
- 백엔드 DTO/endpoint 기준으로 로그인, 이메일 인증 메일 발송, 이메일 인증, 회원가입, 로그아웃 API 연결
- zustand auth store 추가 및 localStorage.accessToken 기반 초기 hydration 적용
- 로그인/회원가입/이메일 인증 페이지를 react-hook-form + zod 기반 인터랙티브 폼으로 변경
- 제출 중 버튼 disabled, 로딩 문구, 서버 에러 박스 표시 추가
- /onboarding, /lobby, /mypage에 ProtectedRoute 적용
- ProtectedRoute가 localStorage 직접 접근 대신 auth store를 참조하도록 수정
- 헤더 메뉴를 로그인 상태에 따라 분기하고 로그아웃 버튼 추가
- 좌측 상단 Safe or Scam 링크를 비로그인 시 /, 로그인 시 /lobby로 이동하도록 변경
- toApiError 공통 에러 변환 함수 추가
- Vite dev proxy 추가 및 .env.example에 로컬 개발 시 상대 경로 API 사용 방침 반영
- React Query Devtools 추가 및 main.tsx에 마운트

## 체크리스트
- [x] 코드 포맷팅(Checkstyle, Lint 등)을 적용하였는가?
- [x] 테스트 코드를 작성하고 통과했는가?
- [x] 불필요한 console.log / print 등을 제거했는가?
- [x] 로컬 테스트를 완료했는가?
- [x] 관련 서비스 동작을 확인했는가?

## 테스트
1. npm run lint
2. npm run build
3. npm run dev 정상 기동 확인
4. 프론트 dev server HTTP 200 응답 확인

실제 백엔드 연동 회원가입/로그인 수동 검증
로컬 백엔드, PostgreSQL, Redis, Mailpit 실행 후 확인 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 인증 시스템 추가: 회원가입, 로그인, 로그아웃, 이메일 인증 기능 구현
  * 인증 상태에 따른 동적 네비게이션: 미인증 사용자는 로그인/회원가입 버튼, 인증 사용자는 로비/마이페이지/로그아웃 표시
  * 보호된 경로 추가: 인증되지 않은 사용자의 특정 페이지 접근 제한

* **개선**
  * 로그인, 회원가입, 이메일 인증 페이지의 폼 검증 및 오류 처리 강화
  * 개발 환경 도구 추가: React Query DevTools 통합

<!-- end of auto-generated comment: release notes by coderabbit.ai -->