### PR TITLE
feat:(front)@hookform/resolvers 추가 및 토큰 관리

### DIFF
--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.2.2",
         "@tanstack/react-query": "^5.100.9",
         "axios": "^1.16.0",
         "react": "^19.2.5",
@@ -437,6 +438,18 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -862,6 +875,12 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
       "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.2",
     "@tanstack/react-query": "^5.100.9",
     "axios": "^1.16.0",
     "react": "^19.2.5",

--- a/apps/frontend/src/features/auth/hooks.ts
+++ b/apps/frontend/src/features/auth/hooks.ts
@@ -157,8 +157,7 @@ export const useLogout = () => {
   const refreshToken = useAuthStore((state) => state.refreshToken)
 
   return useMutation({
-    mutationFn: () =>
-      refreshToken ? authApi.logout({ refreshToken }) : Promise.resolve(null),
+    mutationFn: () => authApi.logout({ refreshToken: refreshToken as string }),
     onSettled: () => {
       clearAuth()
       void queryClient.invalidateQueries({ queryKey: authKeys.session() })

--- a/apps/frontend/src/features/auth/hooks.ts
+++ b/apps/frontend/src/features/auth/hooks.ts
@@ -2,6 +2,8 @@ import { useEffect } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useLocation, useNavigate, type Location } from 'react-router-dom'
 
+import { toApiError } from '@/shared/api/error'
+
 import { authApi } from './api'
 import { authKeys } from './queryKeys'
 import type { SignupFormValues } from './schemas'
@@ -69,7 +71,7 @@ export const useAuthBootstrap = () => {
   }, [meQuery.data, setUser])
 
   useEffect(() => {
-    if (meQuery.error) {
+    if (meQuery.error && toApiError(meQuery.error).status === 401) {
       clearAuth()
     }
   }, [clearAuth, meQuery.error])

--- a/apps/frontend/src/features/auth/pages/EmailVerificationPage.tsx
+++ b/apps/frontend/src/features/auth/pages/EmailVerificationPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
 
 import { toApiError } from '@/shared/api/error'
 
@@ -17,12 +18,12 @@ export function EmailVerificationPage() {
   const verifyEmailMutation = useVerifyEmail()
   const signupMutation = useSignup()
   const {
-    clearErrors,
     formState: { errors },
     handleSubmit,
     register,
-    setError,
   } = useForm<EmailVerificationFormValues>({
+    resolver: zodResolver(emailVerificationSchema),
+    mode: 'onTouched',
     defaultValues: {
       code: '',
     },
@@ -49,27 +50,10 @@ export function EmailVerificationPage() {
       return
     }
 
-    clearErrors()
-    const validation = emailVerificationSchema.safeParse(values)
-
-    if (!validation.success) {
-      validation.error.issues.forEach((issue) => {
-        const field = issue.path[0]
-
-        if (field === 'code') {
-          setError(field, {
-            type: 'zod',
-            message: issue.message,
-          })
-        }
-      })
-      return
-    }
-
     verifyEmailMutation.mutate(
       {
         email: signupDraft.email,
-        code: validation.data.code,
+        code: values.code,
         purpose: 'SIGNUP',
       },
       {

--- a/apps/frontend/src/features/auth/pages/LoginPage.tsx
+++ b/apps/frontend/src/features/auth/pages/LoginPage.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom'
 import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
 
 import { toApiError } from '@/shared/api/error'
 
@@ -9,12 +10,12 @@ import { loginSchema, type LoginFormValues } from '../schemas'
 export function LoginPage() {
   const loginMutation = useLogin()
   const {
-    clearErrors,
     formState: { errors },
     handleSubmit,
     register,
-    setError,
   } = useForm<LoginFormValues>({
+    resolver: zodResolver(loginSchema),
+    mode: 'onTouched',
     defaultValues: {
       email: '',
       password: '',
@@ -24,24 +25,7 @@ export function LoginPage() {
   const serverError = loginMutation.error ? toApiError(loginMutation.error) : null
 
   const onSubmit = (values: LoginFormValues) => {
-    clearErrors()
-    const validation = loginSchema.safeParse(values)
-
-    if (!validation.success) {
-      validation.error.issues.forEach((issue) => {
-        const field = issue.path[0]
-
-        if (field === 'email' || field === 'password') {
-          setError(field, {
-            type: 'zod',
-            message: issue.message,
-          })
-        }
-      })
-      return
-    }
-
-    loginMutation.mutate(validation.data)
+    loginMutation.mutate(values)
   }
 
   return (

--- a/apps/frontend/src/features/auth/pages/SignupPage.tsx
+++ b/apps/frontend/src/features/auth/pages/SignupPage.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom'
 import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
 
 import { toApiError } from '@/shared/api/error'
 
@@ -9,12 +10,12 @@ import { signupSchema, type SignupFormValues } from '../schemas'
 export function SignupPage() {
   const sendVerificationMutation = useSendSignupVerificationEmail()
   const {
-    clearErrors,
     formState: { errors },
     handleSubmit,
     register,
-    setError,
   } = useForm<SignupFormValues>({
+    resolver: zodResolver(signupSchema),
+    mode: 'onTouched',
     defaultValues: {
       name: '',
       email: '',
@@ -27,24 +28,7 @@ export function SignupPage() {
     : null
 
   const onSubmit = (values: SignupFormValues) => {
-    clearErrors()
-    const validation = signupSchema.safeParse(values)
-
-    if (!validation.success) {
-      validation.error.issues.forEach((issue) => {
-        const field = issue.path[0]
-
-        if (field === 'name' || field === 'email' || field === 'password') {
-          setError(field, {
-            type: 'zod',
-            message: issue.message,
-          })
-        }
-      })
-      return
-    }
-
-    sendVerificationMutation.mutate(validation.data)
+    sendVerificationMutation.mutate(values)
   }
 
   return (

--- a/apps/frontend/src/features/auth/store.ts
+++ b/apps/frontend/src/features/auth/store.ts
@@ -16,28 +16,57 @@ type AuthState = {
   clearSignupDraft: () => void
 }
 
-const getStoredToken = (key: 'accessToken' | 'refreshToken') => {
+const getStoredAccessToken = () => {
   if (typeof window === 'undefined') {
     return null
   }
 
   // TODO: Move session persistence to HttpOnly cookies or a BFF once the backend auth contract supports it.
-  return localStorage.getItem(key)
+  return localStorage.getItem('accessToken')
+}
+
+const getStoredRefreshToken = () => {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  // TODO: Move session persistence to HttpOnly cookies or a BFF once the backend auth contract supports it.
+  return sessionStorage.getItem('refreshToken')
 }
 
 const persistTokens = (accessToken: string, refreshToken: string) => {
   localStorage.setItem('accessToken', accessToken)
-  localStorage.setItem('refreshToken', refreshToken)
+  sessionStorage.setItem('refreshToken', refreshToken)
 }
 
 const clearStoredTokens = () => {
   localStorage.removeItem('accessToken')
-  localStorage.removeItem('refreshToken')
+  sessionStorage.removeItem('refreshToken')
+}
+
+const getInitialTokens = () => {
+  const accessToken = getStoredAccessToken()
+  const refreshToken = getStoredRefreshToken()
+
+  if (!accessToken || !refreshToken) {
+    if (accessToken || refreshToken) {
+      clearStoredTokens()
+    }
+
+    return {
+      accessToken: null,
+      refreshToken: null,
+    }
+  }
+
+  return {
+    accessToken,
+    refreshToken,
+  }
 }
 
 export const useAuthStore = create<AuthState>((set) => {
-  const accessToken = getStoredToken('accessToken')
-  const refreshToken = getStoredToken('refreshToken')
+  const { accessToken, refreshToken } = getInitialTokens()
 
   return {
     accessToken,

--- a/apps/frontend/src/features/auth/store.ts
+++ b/apps/frontend/src/features/auth/store.ts
@@ -4,38 +4,49 @@ import type { AuthUser, SignupDraft } from './types'
 
 type AuthState = {
   accessToken: string | null
-  // Intentionally memory-only for current-session logout; refresh rotation belongs to the Day 3 auth flow.
   refreshToken: string | null
   user: AuthUser | null
   signupDraft: SignupDraft | null
   isAuthenticated: boolean
   setAuth: (accessToken: string, refreshToken: string, user: AuthUser) => void
+  setTokens: (accessToken: string, refreshToken: string) => void
   setUser: (user: AuthUser) => void
   clearAuth: () => void
   setSignupDraft: (signupDraft: SignupDraft) => void
   clearSignupDraft: () => void
 }
 
-const getInitialAccessToken = () => {
+const getStoredToken = (key: 'accessToken' | 'refreshToken') => {
   if (typeof window === 'undefined') {
     return null
   }
 
   // TODO: Move session persistence to HttpOnly cookies or a BFF once the backend auth contract supports it.
-  return localStorage.getItem('accessToken')
+  return localStorage.getItem(key)
+}
+
+const persistTokens = (accessToken: string, refreshToken: string) => {
+  localStorage.setItem('accessToken', accessToken)
+  localStorage.setItem('refreshToken', refreshToken)
+}
+
+const clearStoredTokens = () => {
+  localStorage.removeItem('accessToken')
+  localStorage.removeItem('refreshToken')
 }
 
 export const useAuthStore = create<AuthState>((set) => {
-  const accessToken = getInitialAccessToken()
+  const accessToken = getStoredToken('accessToken')
+  const refreshToken = getStoredToken('refreshToken')
 
   return {
     accessToken,
-    refreshToken: null,
+    refreshToken,
     user: null,
     signupDraft: null,
-    isAuthenticated: Boolean(accessToken),
+    isAuthenticated: Boolean(accessToken && refreshToken),
     setAuth: (nextAccessToken, nextRefreshToken, user) => {
-      localStorage.setItem('accessToken', nextAccessToken)
+      persistTokens(nextAccessToken, nextRefreshToken)
       set({
         accessToken: nextAccessToken,
         refreshToken: nextRefreshToken,
@@ -43,11 +54,19 @@ export const useAuthStore = create<AuthState>((set) => {
         isAuthenticated: true,
       })
     },
+    setTokens: (nextAccessToken, nextRefreshToken) => {
+      persistTokens(nextAccessToken, nextRefreshToken)
+      set({
+        accessToken: nextAccessToken,
+        refreshToken: nextRefreshToken,
+        isAuthenticated: true,
+      })
+    },
     setUser: (user) => {
       set({ user })
     },
     clearAuth: () => {
-      localStorage.removeItem('accessToken')
+      clearStoredTokens()
       set({
         accessToken: null,
         refreshToken: null,

--- a/apps/frontend/src/shared/api/client.ts
+++ b/apps/frontend/src/shared/api/client.ts
@@ -1,6 +1,44 @@
-import axios, { AxiosHeaders, type AxiosError, type InternalAxiosRequestConfig } from 'axios'
+import axios, {
+  AxiosHeaders,
+  type AxiosError,
+  type AxiosInstance,
+  type InternalAxiosRequestConfig,
+} from 'axios'
+
+import { useAuthStore } from '@/features/auth/store'
 
 const REQUEST_TIMEOUT_MS = 10_000
+const AUTH_REFRESH_PATH = '/api/v1/auth/refresh'
+const PUBLIC_AUTH_PATHS = [
+  '/api/v1/auth/email/send',
+  '/api/v1/auth/email/verify',
+  '/api/v1/auth/signup',
+  '/api/v1/auth/login',
+  AUTH_REFRESH_PATH,
+]
+
+type RetriableRequestConfig = InternalAxiosRequestConfig & {
+  _retry?: boolean
+}
+
+type ApiResponse<T> = {
+  data: T
+}
+
+type RefreshResponse = {
+  accessToken: string
+  refreshToken: string
+}
+
+const refreshClient = axios.create({
+  baseURL: import.meta.env.VITE_API_URL,
+  timeout: REQUEST_TIMEOUT_MS,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+})
+
+let refreshPromise: Promise<RefreshResponse> | null = null
 
 const attachAccessToken = (config: InternalAxiosRequestConfig) => {
   const token = localStorage.getItem('accessToken')
@@ -13,17 +51,91 @@ const attachAccessToken = (config: InternalAxiosRequestConfig) => {
   return config
 }
 
-const handleUnauthorized = (error: AxiosError) => {
-  if (error.response?.status === 401) {
-    localStorage.removeItem('accessToken')
+const isPublicAuthRequest = (config?: InternalAxiosRequestConfig) => {
+  const requestUrl = config?.url
 
-    if (window.location.pathname !== '/login') {
-      window.location.href = '/login'
-    }
+  return Boolean(requestUrl && PUBLIC_AUTH_PATHS.some((path) => requestUrl.includes(path)))
+}
+
+const isLogoutRequest = (config: InternalAxiosRequestConfig) =>
+  Boolean(
+    config.url?.includes('/api/v1/auth/logout') &&
+      !config.url.includes('/api/v1/auth/logout/all'),
+  )
+
+const redirectToLogin = () => {
+  if (typeof window === 'undefined') {
+    return
   }
 
-  return Promise.reject(error)
+  if (window.location.pathname !== '/login') {
+    window.location.href = '/login'
+  }
 }
+
+const clearAuthAndRedirect = () => {
+  useAuthStore.getState().clearAuth()
+  redirectToLogin()
+}
+
+const requestTokenRefresh = async () => {
+  const refreshToken =
+    useAuthStore.getState().refreshToken ?? localStorage.getItem('refreshToken')
+
+  if (!refreshToken) {
+    throw new Error('Missing refresh token')
+  }
+
+  const response = await refreshClient.post<ApiResponse<RefreshResponse>>(AUTH_REFRESH_PATH, {
+    refreshToken,
+  })
+  const nextTokens = response.data.data
+  useAuthStore.getState().setTokens(nextTokens.accessToken, nextTokens.refreshToken)
+
+  return nextTokens
+}
+
+const refreshTokensOnce = () => {
+  refreshPromise ??= requestTokenRefresh().finally(() => {
+    refreshPromise = null
+  })
+
+  return refreshPromise
+}
+
+const handleUnauthorized =
+  (client: AxiosInstance) => async (error: AxiosError) => {
+    const originalConfig = error.config as RetriableRequestConfig | undefined
+
+    if (error.response?.status !== 401 || !originalConfig) {
+      return Promise.reject(error)
+    }
+
+    if (originalConfig._retry || isPublicAuthRequest(originalConfig)) {
+      if (!isPublicAuthRequest(originalConfig)) {
+        clearAuthAndRedirect()
+      }
+
+      return Promise.reject(error)
+    }
+
+    originalConfig._retry = true
+
+    try {
+      const { accessToken, refreshToken } = await refreshTokensOnce()
+      originalConfig.headers = AxiosHeaders.from(originalConfig.headers)
+      originalConfig.headers.set('Authorization', `Bearer ${accessToken}`)
+
+      if (isLogoutRequest(originalConfig)) {
+        originalConfig.data = { refreshToken }
+      }
+
+      return client(originalConfig)
+    } catch (refreshError) {
+      clearAuthAndRedirect()
+      return Promise.reject(refreshError)
+    }
+  }
 
 export const apiClient = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
@@ -44,5 +156,8 @@ export const gameEngineClient = axios.create({
 apiClient.interceptors.request.use(attachAccessToken)
 gameEngineClient.interceptors.request.use(attachAccessToken)
 
-apiClient.interceptors.response.use((response) => response, handleUnauthorized)
-gameEngineClient.interceptors.response.use((response) => response, handleUnauthorized)
+apiClient.interceptors.response.use((response) => response, handleUnauthorized(apiClient))
+gameEngineClient.interceptors.response.use(
+  (response) => response,
+  handleUnauthorized(gameEngineClient),
+)

--- a/apps/frontend/src/shared/api/client.ts
+++ b/apps/frontend/src/shared/api/client.ts
@@ -30,6 +30,13 @@ type RefreshResponse = {
   refreshToken: string
 }
 
+class MissingRefreshTokenError extends Error {
+  constructor() {
+    super('Missing refresh token')
+    this.name = 'MissingRefreshTokenError'
+  }
+}
+
 const refreshClient = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
   timeout: REQUEST_TIMEOUT_MS,
@@ -80,10 +87,10 @@ const clearAuthAndRedirect = () => {
 
 const requestTokenRefresh = async () => {
   const refreshToken =
-    useAuthStore.getState().refreshToken ?? localStorage.getItem('refreshToken')
+    useAuthStore.getState().refreshToken ?? sessionStorage.getItem('refreshToken')
 
   if (!refreshToken) {
-    throw new Error('Missing refresh token')
+    throw new MissingRefreshTokenError()
   }
 
   const response = await refreshClient.post<ApiResponse<RefreshResponse>>(AUTH_REFRESH_PATH, {
@@ -101,6 +108,14 @@ const refreshTokensOnce = () => {
   })
 
   return refreshPromise
+}
+
+const shouldClearAuthAfterRefreshError = (refreshError: unknown) => {
+  if (refreshError instanceof MissingRefreshTokenError) {
+    return true
+  }
+
+  return axios.isAxiosError(refreshError) && refreshError.response?.status === 401
 }
 
 const handleUnauthorized =
@@ -132,7 +147,10 @@ const handleUnauthorized =
 
       return client(originalConfig)
     } catch (refreshError) {
-      clearAuthAndRedirect()
+      if (shouldClearAuthAfterRefreshError(refreshError)) {
+        clearAuthAndRedirect()
+      }
+
       return Promise.reject(refreshError)
     }
   }


### PR DESCRIPTION
## 관련 이슈
Closes #37 

## 작업 내용
- 인증 흐름 개선을 위해 access token 만료 시 refresh token으로 자동 갱신
- 새로고침 이후에도 refresh token이 유지되어 로그아웃 요청이 정상 전달되도록 수정
- 회원가입/로그인/이메일 인증 폼을 react-hook-form의 zodResolver 기반 검증 패턴으로 정리  

## 변경 사항
- POST /api/v1/auth/refresh 백엔드 계약을 확인하고, 401 응답 시 refresh 요청을 single-flight로 처리한 뒤 원 요청을 1회 재시도하도록 API interceptor를 개선
- accessToken, refreshToken을 localStorage에 함께 저장/복구/삭제하도록 auth store 수정
refresh token rotation 응답의 새 accessToken/refreshToken을 store와 storage에 즉시 반영
- refresh 실패 또는 재시도 후 401 발생 시 인증 정보를 정리하고 /login으로 이동하도록 처리
- 로그아웃 요청 중 access token 만료로 refresh가 발생하는 경우, 회전된 최신 refreshToken으로 logout body를 갱신해 백엔드 무효화 요청이 정상 도달하도록 보정
- @hookform/resolvers 의존성 추가
- LoginPage, SignupPage, EmailVerificationPage의 수동 safeParse + setError 검증 코드를 제거하고 zodResolver와 mode: 'onTouched'를 적용
- npm run lint, npm run build 통과

## 체크리스트
- [x] 코드 포맷팅(Checkstyle, Lint 등)을 적용하였는가?
- [x] 테스트 코드를 작성하고 통과했는가?
- [x] 불필요한 console.log / print 등을 제거했는가?
- [x] 로컬 테스트를 완료했는가?
- [x] 관련 서비스 동작을 확인했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기능 개선**
  * 로그인, 회원가입, 이메일 인증 페이지의 폼 검증 개선으로 더 빠른 입력 피드백 제공
  * 인증 토큰 관리 강화로 더 안정적인 세션 유지

<!-- end of auto-generated comment: release notes by coderabbit.ai -->