### PR TITLE
[Feat] (front) User 정보 조회 및 수정, 회원탈퇴 API 연동

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -65,7 +65,7 @@ function App() {
           <Route
             path="/onboarding"
             element={
-              <ProtectedRoute>
+              <ProtectedRoute allowedRoles={['GUEST']}>
                 <OnboardingPage />
               </ProtectedRoute>
             }
@@ -73,7 +73,7 @@ function App() {
           <Route
             path="/lobby"
             element={
-              <ProtectedRoute>
+              <ProtectedRoute allowedRoles={['USER']}>
                 <LobbyPage />
               </ProtectedRoute>
             }
@@ -81,7 +81,7 @@ function App() {
           <Route
             path="/mypage"
             element={
-              <ProtectedRoute>
+              <ProtectedRoute allowedRoles={['USER']}>
                 <MyPage />
               </ProtectedRoute>
             }

--- a/apps/frontend/src/features/auth/hooks.ts
+++ b/apps/frontend/src/features/auth/hooks.ts
@@ -8,37 +8,11 @@ import { authApi } from './api'
 import { authKeys } from './queryKeys'
 import type { SignupFormValues } from './schemas'
 import { useAuthStore } from './store'
-import type {
-  AuthUser,
-  EmailVerifyRequest,
-  LoginResponse,
-  MeResponse,
-  SignupResponse,
-  SignupRequest,
-} from './types'
+import type { EmailVerifyRequest, SignupRequest } from './types'
 
 type RedirectState = {
   from?: Pick<Location, 'pathname' | 'search' | 'hash'>
 }
-
-const normalizeLoginUser = (user: LoginResponse['user']): AuthUser => ({
-  id: user.id,
-  email: user.email,
-  name: user.name,
-  role: user.role,
-})
-
-const normalizeSignupUser = (user: SignupResponse['user']): AuthUser => ({
-  id: user.userId,
-  email: user.email,
-  name: user.name,
-  role: user.role,
-})
-
-const normalizeMeUser = (user: MeResponse): AuthUser => ({
-  email: user.email,
-  name: user.name,
-})
 
 const getRedirectPath = (state: unknown) => {
   const redirectState = state as RedirectState | null
@@ -53,22 +27,14 @@ const getRedirectPath = (state: unknown) => {
 
 export const useAuthBootstrap = () => {
   const accessToken = useAuthStore((state) => state.accessToken)
-  const user = useAuthStore((state) => state.user)
-  const setUser = useAuthStore((state) => state.setUser)
   const clearAuth = useAuthStore((state) => state.clearAuth)
 
   const meQuery = useQuery({
     queryKey: authKeys.user(),
     queryFn: ({ signal }) => authApi.getMe({ signal }),
-    enabled: Boolean(accessToken && !user),
+    enabled: Boolean(accessToken),
     retry: false,
   })
-
-  useEffect(() => {
-    if (meQuery.data) {
-      setUser(normalizeMeUser(meQuery.data))
-    }
-  }, [meQuery.data, setUser])
 
   useEffect(() => {
     if (meQuery.error && toApiError(meQuery.error).status === 401) {
@@ -77,7 +43,7 @@ export const useAuthBootstrap = () => {
   }, [clearAuth, meQuery.error])
 
   return {
-    isLoadingUser: Boolean(accessToken && !user && meQuery.isPending),
+    isLoadingUser: Boolean(accessToken && meQuery.isPending),
   }
 }
 
@@ -128,7 +94,7 @@ export const useSignup = () => {
   return useMutation({
     mutationFn: (request: SignupRequest) => authApi.signup(request),
     onSuccess: (response) => {
-      setAuth(response.accessToken, response.refreshToken, normalizeSignupUser(response.user))
+      setAuth(response.accessToken, response.refreshToken, response.user.role)
       clearSignupDraft()
       void queryClient.invalidateQueries({ queryKey: authKeys.session() })
       navigate('/onboarding', { replace: true })
@@ -145,7 +111,7 @@ export const useLogin = () => {
   return useMutation({
     mutationFn: authApi.login,
     onSuccess: (response) => {
-      setAuth(response.accessToken, response.refreshToken, normalizeLoginUser(response.user))
+      setAuth(response.accessToken, response.refreshToken, response.user.role)
       void queryClient.invalidateQueries({ queryKey: authKeys.session() })
       navigate(getRedirectPath(location.state), { replace: true })
     },

--- a/apps/frontend/src/features/auth/hooks.ts
+++ b/apps/frontend/src/features/auth/hooks.ts
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useLocation, useNavigate, type Location } from 'react-router-dom'
 
 import { toApiError } from '@/shared/api/error'
+import { userKeys } from '@/features/user/queryKeys'
 
 import { authApi } from './api'
 import { authKeys } from './queryKeys'
@@ -27,6 +28,8 @@ const getRedirectPath = (state: unknown) => {
 
 export const useAuthBootstrap = () => {
   const accessToken = useAuthStore((state) => state.accessToken)
+  const role = useAuthStore((state) => state.role)
+  const setRole = useAuthStore((state) => state.setRole)
   const clearAuth = useAuthStore((state) => state.clearAuth)
 
   const meQuery = useQuery({
@@ -41,6 +44,30 @@ export const useAuthBootstrap = () => {
       clearAuth()
     }
   }, [clearAuth, meQuery.error])
+
+  useEffect(() => {
+    if (!accessToken || role || meQuery.isPending) {
+      return
+    }
+
+    if (meQuery.data?.role) {
+      setRole(meQuery.data.role)
+      return
+    }
+
+    if (meQuery.isSuccess || meQuery.isError) {
+      clearAuth()
+    }
+  }, [
+    accessToken,
+    clearAuth,
+    meQuery.data?.role,
+    meQuery.isError,
+    meQuery.isPending,
+    meQuery.isSuccess,
+    role,
+    setRole,
+  ])
 
   return {
     isLoadingUser: Boolean(accessToken && meQuery.isPending),
@@ -128,6 +155,7 @@ export const useLogout = () => {
     mutationFn: () => authApi.logout({ refreshToken: refreshToken as string }),
     onSettled: () => {
       clearAuth()
+      queryClient.removeQueries({ queryKey: userKeys.me() })
       void queryClient.invalidateQueries({ queryKey: authKeys.session() })
       navigate('/login', { replace: true })
     },

--- a/apps/frontend/src/features/auth/pages/LoginPage.tsx
+++ b/apps/frontend/src/features/auth/pages/LoginPage.tsx
@@ -1,4 +1,5 @@
-import { Link } from 'react-router-dom'
+import { useEffect, useState } from 'react'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 
@@ -7,8 +8,19 @@ import { toApiError } from '@/shared/api/error'
 import { useLogin } from '../hooks'
 import { loginSchema, type LoginFormValues } from '../schemas'
 
+type LoginLocationState = {
+  withdrawalComplete?: boolean
+}
+
 export function LoginPage() {
+  const location = useLocation()
+  const navigate = useNavigate()
   const loginMutation = useLogin()
+  const [notice, setNotice] = useState<string | null>(() =>
+    (location.state as LoginLocationState | null)?.withdrawalComplete
+      ? '탈퇴가 완료되었어요.'
+      : null,
+  )
   const {
     formState: { errors },
     handleSubmit,
@@ -24,12 +36,44 @@ export function LoginPage() {
 
   const serverError = loginMutation.error ? toApiError(loginMutation.error) : null
 
+  useEffect(() => {
+    if (!(location.state as LoginLocationState | null)?.withdrawalComplete) {
+      return
+    }
+
+    navigate(location.pathname, { replace: true, state: null })
+  }, [location.pathname, location.state, navigate])
+
+  useEffect(() => {
+    if (!notice) {
+      return
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setNotice(null)
+    }, 2000)
+
+    return () => {
+      window.clearTimeout(timeoutId)
+    }
+  }, [notice])
+
   const onSubmit = (values: LoginFormValues) => {
     loginMutation.mutate(values)
   }
 
   return (
     <section className="mx-auto max-w-md space-y-6 py-10">
+      {notice ? (
+        <div
+          role="status"
+          aria-live="polite"
+          className="fixed right-5 top-20 z-40 rounded-md border border-emerald-300/30 bg-emerald-400 px-4 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-slate-950/30"
+        >
+          {notice}
+        </div>
+      ) : null}
+
       <div className="space-y-2">
         <h1 className="text-3xl font-semibold text-white">로그인</h1>
         <p className="text-slate-300">학습 기록과 맞춤 시나리오를 이어서 확인합니다.</p>

--- a/apps/frontend/src/features/auth/store.ts
+++ b/apps/frontend/src/features/auth/store.ts
@@ -1,16 +1,16 @@
 import { create } from 'zustand'
 
-import type { AuthUser, SignupDraft } from './types'
+import type { SignupDraft, UserRole } from './types'
 
 type AuthState = {
   accessToken: string | null
   refreshToken: string | null
-  user: AuthUser | null
+  role: UserRole | null
   signupDraft: SignupDraft | null
   isAuthenticated: boolean
-  setAuth: (accessToken: string, refreshToken: string, user: AuthUser) => void
+  setAuth: (accessToken: string, refreshToken: string, role: UserRole) => void
   setTokens: (accessToken: string, refreshToken: string) => void
-  setUser: (user: AuthUser) => void
+  setRole: (role: UserRole) => void
   clearAuth: () => void
   setSignupDraft: (signupDraft: SignupDraft) => void
   clearSignupDraft: () => void
@@ -34,14 +34,29 @@ const getStoredRefreshToken = () => {
   return sessionStorage.getItem('refreshToken')
 }
 
+const getStoredRole = () => {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  const role = sessionStorage.getItem('userRole')
+
+  return role === 'GUEST' || role === 'USER' || role === 'ADMIN' ? role : null
+}
+
 const persistTokens = (accessToken: string, refreshToken: string) => {
   localStorage.setItem('accessToken', accessToken)
   sessionStorage.setItem('refreshToken', refreshToken)
 }
 
+const persistRole = (role: UserRole) => {
+  sessionStorage.setItem('userRole', role)
+}
+
 const clearStoredTokens = () => {
   localStorage.removeItem('accessToken')
   sessionStorage.removeItem('refreshToken')
+  sessionStorage.removeItem('userRole')
 }
 
 const getInitialTokens = () => {
@@ -67,19 +82,21 @@ const getInitialTokens = () => {
 
 export const useAuthStore = create<AuthState>((set) => {
   const { accessToken, refreshToken } = getInitialTokens()
+  const role = accessToken && refreshToken ? getStoredRole() : null
 
   return {
     accessToken,
     refreshToken,
-    user: null,
+    role,
     signupDraft: null,
     isAuthenticated: Boolean(accessToken && refreshToken),
-    setAuth: (nextAccessToken, nextRefreshToken, user) => {
+    setAuth: (nextAccessToken, nextRefreshToken, nextRole) => {
       persistTokens(nextAccessToken, nextRefreshToken)
+      persistRole(nextRole)
       set({
         accessToken: nextAccessToken,
         refreshToken: nextRefreshToken,
-        user,
+        role: nextRole,
         isAuthenticated: true,
       })
     },
@@ -91,15 +108,16 @@ export const useAuthStore = create<AuthState>((set) => {
         isAuthenticated: true,
       })
     },
-    setUser: (user) => {
-      set({ user })
+    setRole: (role) => {
+      persistRole(role)
+      set({ role })
     },
     clearAuth: () => {
       clearStoredTokens()
       set({
         accessToken: null,
         refreshToken: null,
-        user: null,
+        role: null,
         isAuthenticated: false,
       })
     },

--- a/apps/frontend/src/features/auth/types.ts
+++ b/apps/frontend/src/features/auth/types.ts
@@ -60,6 +60,7 @@ export type MeResponse = {
   occupation: string | null
   gender: string | null
   ageGroup: string | null
+  role?: UserRole
 }
 
 export type ApiResponse<T> = {

--- a/apps/frontend/src/features/auth/types.ts
+++ b/apps/frontend/src/features/auth/types.ts
@@ -77,13 +77,6 @@ export type ApiResponse<T> = {
   }
 }
 
-export type AuthUser = {
-  id?: number
-  email: string
-  name: string
-  role?: UserRole
-}
-
 export type SignupDraft = {
   email: string
   name: string

--- a/apps/frontend/src/features/game-session/pages/LobbyPage.tsx
+++ b/apps/frontend/src/features/game-session/pages/LobbyPage.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
+import { useUserProfile } from '@/features/user/hooks'
+
 const scenarios = [
   { title: '택배 배송 주소 확인', difficulty: '초급', status: '추천' },
   { title: '회사 보안 메일 점검', difficulty: '중급', status: '준비됨' },
@@ -23,12 +25,14 @@ const focusableSelector = [
 export function LobbyPage() {
   const location = useLocation()
   const navigate = useNavigate()
+  const profileQuery = useUserProfile()
   const dialogRef = useRef<HTMLDivElement>(null)
   const primaryActionRef = useRef<HTMLButtonElement>(null)
   const previouslyFocusedElementRef = useRef<HTMLElement | null>(null)
   const [isOnboardingPopupOpen, setIsOnboardingPopupOpen] = useState(
     Boolean((location.state as LobbyLocationState | null)?.onboardingComplete),
   )
+  const userName = profileQuery.data?.name?.trim() || '회원'
 
   useEffect(() => {
     const isOnboardingComplete = Boolean(
@@ -140,8 +144,8 @@ export function LobbyPage() {
       ) : null}
 
       <div className="space-y-2">
-        <p className="text-sm font-medium text-emerald-300">온보딩이 완료되었습니다</p>
-        <h1 className="text-3xl font-semibold text-white">안녕하세요, 소영님</h1>
+        <p className="text-sm font-medium text-emerald-300">오늘의 추천 훈련</p>
+        <h1 className="text-3xl font-semibold text-white">안녕하세요, {userName}님</h1>
         <p className="text-slate-300">오늘은 실생활 메시지 피싱을 빠르게 판별하는 훈련을 추천합니다.</p>
       </div>
 

--- a/apps/frontend/src/features/user/api.ts
+++ b/apps/frontend/src/features/user/api.ts
@@ -2,7 +2,14 @@ import type { AxiosResponse } from 'axios'
 
 import { apiClient } from '@/shared/api/client'
 
-import type { OnboardingRequest, OnboardingResponse } from './types'
+import type {
+  OnboardingRequest,
+  OnboardingResponse,
+  UpdateProfileRequest,
+  UpdateProfileResponse,
+  UserProfile,
+  WithdrawalResponse,
+} from './types'
 
 type ApiResponse<T> = {
   data: T
@@ -11,6 +18,23 @@ type ApiResponse<T> = {
 const unwrapData = <T>(response: AxiosResponse<ApiResponse<T>>) => response.data.data
 
 export const userApi = {
+  getMe: async () => {
+    const response = await apiClient.get<ApiResponse<UserProfile>>('/api/v1/users/me')
+    return unwrapData(response)
+  },
+  updateProfile: async (request: UpdateProfileRequest) => {
+    const response = await apiClient.patch<ApiResponse<UpdateProfileResponse>>(
+      '/api/v1/users/me',
+      request,
+    )
+    return unwrapData(response)
+  },
+  withdraw: async () => {
+    const response = await apiClient.post<ApiResponse<WithdrawalResponse>>(
+      '/api/v1/users/me/withdrawal',
+    )
+    return unwrapData(response)
+  },
   completeOnboarding: async (request: OnboardingRequest) => {
     const response = await apiClient.post<ApiResponse<OnboardingResponse>>(
       '/api/v1/users/me/onboarding',

--- a/apps/frontend/src/features/user/hooks.ts
+++ b/apps/frontend/src/features/user/hooks.ts
@@ -9,11 +9,15 @@ import { userKeys } from './queryKeys'
 import { useOnboardingDraftStore } from './store'
 import type { UpdateProfileRequest } from './types'
 
-export const useUserProfile = () =>
-  useQuery({
+export const useUserProfile = () => {
+  const accessToken = useAuthStore((state) => state.accessToken)
+
+  return useQuery({
     queryKey: userKeys.me(),
     queryFn: userApi.getMe,
+    enabled: Boolean(accessToken),
   })
+}
 
 export const useUpdateProfile = () => {
   const queryClient = useQueryClient()

--- a/apps/frontend/src/features/user/hooks.ts
+++ b/apps/frontend/src/features/user/hooks.ts
@@ -1,28 +1,63 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
 
 import { useAuthStore } from '@/features/auth/store'
 import { authKeys } from '@/features/auth/queryKeys'
 
 import { userApi } from './api'
+import { userKeys } from './queryKeys'
 import { useOnboardingDraftStore } from './store'
+import type { UpdateProfileRequest } from './types'
+
+export const useUserProfile = () =>
+  useQuery({
+    queryKey: userKeys.me(),
+    queryFn: userApi.getMe,
+  })
+
+export const useUpdateProfile = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (request: UpdateProfileRequest) => userApi.updateProfile(request),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: userKeys.me() })
+    },
+  })
+}
+
+export const useWithdrawUser = () => {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const clearAuth = useAuthStore((state) => state.clearAuth)
+
+  return useMutation({
+    mutationFn: userApi.withdraw,
+    onSuccess: () => {
+      clearAuth()
+      queryClient.clear()
+      navigate('/login', {
+        replace: true,
+        state: {
+          withdrawalComplete: true,
+        },
+      })
+    },
+  })
+}
 
 export const useCompleteOnboarding = () => {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const setTokens = useAuthStore((state) => state.setTokens)
-  const setUser = useAuthStore((state) => state.setUser)
-  const user = useAuthStore((state) => state.user)
+  const setRole = useAuthStore((state) => state.setRole)
   const clearOnboardingDraft = useOnboardingDraftStore((state) => state.clearOnboardingDraft)
 
   return useMutation({
     mutationFn: userApi.completeOnboarding,
     onSuccess: (response) => {
       setTokens(response.accessToken, response.refreshToken)
-
-      if (user) {
-        setUser({ ...user, role: response.role })
-      }
+      setRole(response.role)
 
       clearOnboardingDraft()
       void queryClient.invalidateQueries({ queryKey: authKeys.session() })

--- a/apps/frontend/src/features/user/pages/MyPage.tsx
+++ b/apps/frontend/src/features/user/pages/MyPage.tsx
@@ -1,6 +1,55 @@
-const jobs = ['학생', '대학(원)생', '구직자', '회사원', '프리랜서', '자영업자', '기타']
-const ageGroups = ['10대', '20대', '30대', '40대', '50대', '60대 이상']
-const genders = ['여성', '남성']
+import { useEffect, useRef, useState, type ChangeEvent, type FormEvent } from 'react'
+
+import { toApiError } from '@/shared/api/error'
+
+import { useUpdateProfile, useUserProfile, useWithdrawUser } from '../hooks'
+import type {
+  AgeGroup,
+  Gender,
+  Occupation,
+  Option,
+  UpdateProfileRequest,
+  UserProfile,
+} from '../types'
+
+type ProfileForm = {
+  occupation: Occupation | ''
+  ageGroup: AgeGroup | ''
+  gender: Gender | ''
+}
+
+type ToastState = {
+  tone: 'success' | 'error'
+  message: string
+} | null
+
+type ProfileTab = 'history' | 'achievements'
+
+const occupationOptions: Option<Occupation>[] = [
+  { value: 'STUDENT_K12', label: '초/중/고 학생' },
+  { value: 'UNIV_STUDENT', label: '대학(원)생' },
+  { value: 'JOB_SEEKER', label: '구직자' },
+  { value: 'EMPLOYEE', label: '회사원' },
+  { value: 'SELF_EMPLOYED', label: '자영업자' },
+  { value: 'FREELANCER', label: '프리랜서' },
+  { value: 'HOMEMAKER', label: '전업주부/주부' },
+  { value: 'UNEMPLOYED', label: '무직' },
+  { value: 'OTHER', label: '기타' },
+]
+
+const ageGroupOptions: Option<AgeGroup>[] = [
+  { value: 'TEENS', label: '10대' },
+  { value: 'TWENTIES', label: '20대' },
+  { value: 'THIRTIES', label: '30대' },
+  { value: 'FORTIES', label: '40대' },
+  { value: 'FIFTIES', label: '50대' },
+  { value: 'SIXTIES_AND_ABOVE', label: '60대 이상' },
+]
+
+const genderOptions: Option<Gender>[] = [
+  { value: 'FEMALE', label: '여성' },
+  { value: 'MALE', label: '남성' },
+]
 
 const scenarioHistory = [
   {
@@ -26,127 +75,554 @@ const scenarioHistory = [
   },
 ]
 
-export function MyPage() {
+const achievements = [
+  { title: '첫 판별 완료', description: '첫 시나리오를 끝까지 플레이하면 열립니다.' },
+  { title: '위험 링크 차단', description: '링크형 피싱을 안전하게 판별하면 열립니다.' },
+  { title: '침착한 확인', description: '추가 확인 선택지를 고르면 열립니다.' },
+]
+
+const focusableSelector = [
+  'a[href]',
+  'button:not([disabled])',
+  'textarea:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',')
+
+const createEmptyForm = (): ProfileForm => ({
+  occupation: '',
+  ageGroup: '',
+  gender: '',
+})
+
+const createFormFromProfile = (profile: UserProfile): ProfileForm => ({
+  occupation: profile.occupation ?? '',
+  ageGroup: profile.ageGroup ?? '',
+  gender: profile.gender ?? '',
+})
+
+const getOptionLabel = <Value extends string>(options: Option<Value>[], value: Value | null) =>
+  options.find((option) => option.value === value)?.label ?? '선택되지 않음'
+
+const createProfileUpdate = (form: ProfileForm): UpdateProfileRequest | null => {
+  if (!form.occupation || !form.ageGroup || !form.gender) {
+    return null
+  }
+
+  return {
+    occupation: form.occupation,
+    ageGroup: form.ageGroup,
+    gender: form.gender,
+  }
+}
+
+const hasProfileChanges = (profile: UserProfile, form: ProfileForm) =>
+  form.occupation !== profile.occupation ||
+  form.ageGroup !== profile.ageGroup ||
+  form.gender !== profile.gender
+
+function ProfileSkeleton() {
   return (
-    <section className="mx-auto max-w-2xl space-y-6 py-10">
+    <div className="space-y-5 rounded-lg border border-white/10 bg-white/3 p-6">
+      <div className="flex items-center gap-4">
+        <div className="size-16 animate-pulse rounded-full bg-slate-800" />
+        <div className="space-y-3">
+          <div className="h-5 w-28 animate-pulse rounded bg-slate-800" />
+          <div className="h-4 w-44 animate-pulse rounded bg-slate-800" />
+        </div>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-3">
+        <div className="h-20 animate-pulse rounded-md bg-slate-800" />
+        <div className="h-20 animate-pulse rounded-md bg-slate-800" />
+        <div className="h-20 animate-pulse rounded-md bg-slate-800" />
+      </div>
+    </div>
+  )
+}
+
+type WithdrawDialogProps = {
+  isSubmitting: boolean
+  onCancel: () => void
+  onConfirm: () => void
+}
+
+function WithdrawDialog({ isSubmitting, onCancel, onConfirm }: WithdrawDialogProps) {
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const cancelButtonRef = useRef<HTMLButtonElement>(null)
+  const previouslyFocusedElementRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    previouslyFocusedElementRef.current = document.activeElement as HTMLElement | null
+    cancelButtonRef.current?.focus()
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        onCancel()
+        return
+      }
+
+      if (event.key !== 'Tab') {
+        return
+      }
+
+      const dialog = dialogRef.current
+      const focusableElements = Array.from(
+        dialog?.querySelectorAll<HTMLElement>(focusableSelector) ?? [],
+      ).filter((element) => !element.hasAttribute('disabled') && !element.getAttribute('aria-hidden'))
+
+      if (!dialog || focusableElements.length === 0) {
+        event.preventDefault()
+        dialog?.focus()
+        return
+      }
+
+      const firstFocusableElement = focusableElements[0]
+      const lastFocusableElement = focusableElements[focusableElements.length - 1]
+
+      if (event.shiftKey && document.activeElement === firstFocusableElement) {
+        event.preventDefault()
+        lastFocusableElement.focus()
+        return
+      }
+
+      if (!event.shiftKey && document.activeElement === lastFocusableElement) {
+        event.preventDefault()
+        firstFocusableElement.focus()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+      previouslyFocusedElementRef.current?.focus()
+    }
+  }, [onCancel])
+
+  return (
+    <div
+      role="presentation"
+      className="fixed inset-0 z-30 flex items-center justify-center bg-slate-950/80 px-5 py-8"
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="withdraw-title"
+        aria-describedby="withdraw-description"
+        tabIndex={-1}
+        className="w-full max-w-md rounded-lg border border-red-300/30 bg-slate-900 p-6 shadow-2xl shadow-slate-950/50"
+      >
+        <p className="text-sm font-semibold text-red-200">계정 삭제</p>
+        <h2 id="withdraw-title" className="mt-3 text-2xl font-semibold text-white">
+          정말 탈퇴하시겠어요?
+        </h2>
+        <div id="withdraw-description" className="mt-3 space-y-3 text-sm leading-6 text-slate-300">
+          <p className="rounded-md border border-red-300/25 bg-red-500/10 px-3 py-2 font-semibold text-red-100">
+            복구할 수 없습니다.
+          </p>
+          <p>
+            탈퇴하면 계정과 활동 기록이 영구 삭제됩니다. 14일 동안 같은 이메일로
+            재가입할 수 있지만, 기존 데이터는 되돌릴 수 없습니다.
+          </p>
+        </div>
+        <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-end">
+          <button
+            ref={cancelButtonRef}
+            type="button"
+            disabled={isSubmitting}
+            onClick={onCancel}
+            className="rounded-md border border-white/10 px-4 py-3 text-sm font-semibold text-slate-200 transition hover:border-emerald-300 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-200 disabled:cursor-not-allowed disabled:text-slate-500"
+          >
+            취소
+          </button>
+          <button
+            type="button"
+            disabled={isSubmitting}
+            onClick={onConfirm}
+            className="rounded-md bg-red-400 px-4 py-3 text-sm font-semibold text-slate-950 transition hover:bg-red-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-200 disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-400"
+          >
+            {isSubmitting ? '탈퇴 처리 중...' : '탈퇴하기'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function MyPage() {
+  const profileQuery = useUserProfile()
+  const updateProfileMutation = useUpdateProfile()
+  const withdrawUserMutation = useWithdrawUser()
+  const [form, setForm] = useState<ProfileForm>(createEmptyForm)
+  const [isEditing, setIsEditing] = useState(false)
+  const [toast, setToast] = useState<ToastState>(null)
+  const [activeTab, setActiveTab] = useState<ProfileTab>('history')
+  const [isWithdrawDialogOpen, setIsWithdrawDialogOpen] = useState(false)
+
+  const profile = profileQuery.data
+  const currentForm = isEditing || !profile ? form : createFormFromProfile(profile)
+  const profileUpdate = createProfileUpdate(currentForm)
+  const isDirty = profile ? hasProfileChanges(profile, currentForm) : false
+  const isSavingDisabled = !isEditing || !profileUpdate || updateProfileMutation.isPending
+
+  useEffect(() => {
+    if (!toast) {
+      return
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setToast(null)
+    }, 2000)
+
+    return () => {
+      window.clearTimeout(timeoutId)
+    }
+  }, [toast])
+
+  const handleFieldChange =
+    (field: keyof ProfileForm) => (event: ChangeEvent<HTMLSelectElement>) => {
+      setForm((currentForm) => ({
+        ...currentForm,
+        [field]: event.target.value,
+      }))
+    }
+
+  const handleCancelEdit = () => {
+    if (profile) {
+      setForm(createFormFromProfile(profile))
+    }
+    setIsEditing(false)
+  }
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    if (!profileUpdate) {
+      setToast({ tone: 'error', message: '직업, 연령대, 성별을 모두 선택해주세요.' })
+      return
+    }
+
+    updateProfileMutation.mutate(profileUpdate, {
+      onSuccess: () => {
+        setIsEditing(false)
+        setToast({ tone: 'success', message: '저장되었어요.' })
+      },
+      onError: () => {
+        setToast({ tone: 'error', message: '회원 정보를 저장하지 못했어요. 다시 시도해주세요.' })
+      },
+    })
+  }
+
+  const handleWithdraw = () => {
+    withdrawUserMutation.mutate(undefined, {
+      onError: (error) => {
+        setToast({ tone: 'error', message: toApiError(error).message })
+      },
+    })
+  }
+
+  if (profileQuery.isPending) {
+    return (
+      <section className="mx-auto max-w-4xl space-y-6 py-10">
+        <div className="space-y-2">
+          <h1 className="text-3xl font-semibold text-white">마이페이지</h1>
+          <p className="text-slate-300">내 계정과 맞춤 훈련 설정을 확인합니다.</p>
+        </div>
+        <ProfileSkeleton />
+      </section>
+    )
+  }
+
+  if (profileQuery.isError) {
+    return (
+      <section className="mx-auto max-w-2xl space-y-6 py-10">
+        <div className="space-y-2">
+          <h1 className="text-3xl font-semibold text-white">마이페이지</h1>
+          <p className="text-slate-300">프로필 정보를 불러오지 못했습니다.</p>
+        </div>
+        <div className="rounded-lg border border-red-300/25 bg-red-500/10 p-6">
+          <p className="text-sm text-red-100">{toApiError(profileQuery.error).message}</p>
+          <button
+            type="button"
+            onClick={() => void profileQuery.refetch()}
+            className="mt-4 rounded-md bg-emerald-400 px-4 py-3 text-sm font-semibold text-slate-950 hover:bg-emerald-300"
+          >
+            다시 시도
+          </button>
+        </div>
+      </section>
+    )
+  }
+
+  if (!profile) {
+    return null
+  }
+
+  return (
+    <section className="mx-auto max-w-4xl space-y-6 py-10">
+      {toast ? (
+        <div
+          role="status"
+          aria-live="polite"
+          className={`fixed right-5 top-20 z-40 rounded-md border px-4 py-3 text-sm font-semibold shadow-lg shadow-slate-950/30 ${
+            toast.tone === 'success'
+              ? 'border-emerald-300/30 bg-emerald-400 text-slate-950'
+              : 'border-red-300/30 bg-red-500 text-white'
+          }`}
+        >
+          {toast.message}
+        </div>
+      ) : null}
+
+      {isWithdrawDialogOpen ? (
+        <WithdrawDialog
+          isSubmitting={withdrawUserMutation.isPending}
+          onCancel={() => {
+            if (!withdrawUserMutation.isPending) {
+              setIsWithdrawDialogOpen(false)
+            }
+          }}
+          onConfirm={handleWithdraw}
+        />
+      ) : null}
+
       <div className="space-y-2">
         <h1 className="text-3xl font-semibold text-white">마이페이지</h1>
-        <p className="text-slate-300">가입 정보는 조회만 가능하며, 온보딩 답변만 수정할 수 있습니다.</p>
+        <p className="text-slate-300">내 계정과 맞춤 훈련 설정을 확인합니다.</p>
       </div>
 
-      <section className="space-y-4 rounded-lg border border-white/10 bg-white/3 p-6">
-        <h2 className="text-lg font-semibold text-white">회원 정보</h2>
+      <section className="rounded-lg border border-white/10 bg-white/3 p-6">
+        <div className="flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-4">
+            <div className="flex size-16 items-center justify-center rounded-full border border-emerald-300/40 bg-emerald-300/10 text-2xl font-semibold text-emerald-200">
+              {profile.name.trim().slice(0, 1) || 'S'}
+            </div>
+            <div>
+              <h2 className="text-xl font-semibold text-white">{profile.name}</h2>
+              <p className="mt-1 text-sm text-slate-400">{profile.email}</p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              setForm(createFormFromProfile(profile))
+              setIsEditing(true)
+            }}
+            disabled={isEditing}
+            className="w-full rounded-md border border-white/10 px-4 py-3 text-sm font-semibold text-slate-200 transition hover:border-emerald-300 hover:text-white disabled:cursor-not-allowed disabled:border-white/5 disabled:text-slate-600 sm:w-auto"
+          >
+            수정하기
+          </button>
+        </div>
+      </section>
+
+      <form className="space-y-5 rounded-lg border border-white/10 bg-white/3 p-6" onSubmit={handleSubmit}>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-white">회원 정보</h2>
+            <p className="mt-1 text-sm text-slate-400">이름과 이메일은 현재 수정할 수 없습니다.</p>
+          </div>
+          {isDirty ? (
+            <span className="w-fit rounded-md bg-emerald-300/10 px-2 py-1 text-xs font-medium text-emerald-200">
+              변경사항 있음
+            </span>
+          ) : null}
+        </div>
+
         <div className="grid gap-4 sm:grid-cols-2">
           <div className="rounded-md border border-white/10 bg-slate-900 px-3 py-3">
             <p className="text-sm font-medium text-slate-400">이름</p>
-            <p className="mt-1 font-semibold text-white">소영</p>
+            <p className="mt-1 font-semibold text-white">{profile.name}</p>
           </div>
           <div className="rounded-md border border-white/10 bg-slate-900 px-3 py-3">
-            <p className="text-sm font-medium text-slate-400">메일</p>
-            <p className="mt-1 font-semibold text-white">soyoung@example.com</p>
+            <p className="text-sm font-medium text-slate-400">이메일</p>
+            <p className="mt-1 break-all font-semibold text-white">{profile.email}</p>
           </div>
         </div>
-      </section>
 
-      <form className="space-y-5 rounded-lg border border-white/10 bg-white/3 p-6">
-        <h2 className="text-lg font-semibold text-white">온보딩 답변</h2>
+        <div className="grid gap-4 md:grid-cols-3">
+          <label className="block space-y-2">
+            <span className="text-sm font-medium text-slate-200">직업</span>
+            <select
+              value={currentForm.occupation}
+              disabled={!isEditing || updateProfileMutation.isPending}
+              onChange={handleFieldChange('occupation')}
+              className="w-full rounded-md border border-white/10 bg-slate-900 px-3 py-3 text-white outline-none focus:border-emerald-300 disabled:cursor-not-allowed disabled:bg-slate-950 disabled:text-slate-500"
+            >
+              <option value="">{getOptionLabel(occupationOptions, null)}</option>
+              {occupationOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
 
-        <label className="block space-y-2">
-          <span className="text-sm font-medium text-slate-200">직업</span>
-          <select
-            defaultValue="회사원"
-            className="w-full rounded-md border border-white/10 bg-slate-900 px-3 py-3 text-white outline-none focus:border-emerald-300"
+          <label className="block space-y-2">
+            <span className="text-sm font-medium text-slate-200">연령대</span>
+            <select
+              value={currentForm.ageGroup}
+              disabled={!isEditing || updateProfileMutation.isPending}
+              onChange={handleFieldChange('ageGroup')}
+              className="w-full rounded-md border border-white/10 bg-slate-900 px-3 py-3 text-white outline-none focus:border-emerald-300 disabled:cursor-not-allowed disabled:bg-slate-950 disabled:text-slate-500"
+            >
+              <option value="">{getOptionLabel(ageGroupOptions, null)}</option>
+              {ageGroupOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="block space-y-2">
+            <span className="text-sm font-medium text-slate-200">성별</span>
+            <select
+              value={currentForm.gender}
+              disabled={!isEditing || updateProfileMutation.isPending}
+              onChange={handleFieldChange('gender')}
+              className="w-full rounded-md border border-white/10 bg-slate-900 px-3 py-3 text-white outline-none focus:border-emerald-300 disabled:cursor-not-allowed disabled:bg-slate-950 disabled:text-slate-500"
+            >
+              <option value="">{getOptionLabel(genderOptions, null)}</option>
+              {genderOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+          {isEditing ? (
+            <button
+              type="button"
+              disabled={updateProfileMutation.isPending}
+              onClick={handleCancelEdit}
+              className="rounded-md border border-white/10 px-4 py-3 text-sm font-semibold text-slate-200 transition hover:border-emerald-300 hover:text-white disabled:cursor-not-allowed disabled:text-slate-500"
+            >
+              취소
+            </button>
+          ) : null}
+          <button
+            type="submit"
+            disabled={isSavingDisabled}
+            className="rounded-md bg-emerald-400 px-4 py-3 text-sm font-semibold text-slate-950 transition hover:bg-emerald-300 disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-400"
           >
-            {jobs.map((job) => (
-              <option key={job} value={job}>
-                {job}
-              </option>
-            ))}
-          </select>
-        </label>
-
-        <label className="block space-y-2">
-          <span className="text-sm font-medium text-slate-200">연령대</span>
-          <select
-            defaultValue="20대"
-            className="w-full rounded-md border border-white/10 bg-slate-900 px-3 py-3 text-white outline-none focus:border-emerald-300"
-          >
-            {ageGroups.map((ageGroup) => (
-              <option key={ageGroup} value={ageGroup}>
-                {ageGroup}
-              </option>
-            ))}
-          </select>
-        </label>
-
-        <label className="block space-y-2">
-          <span className="text-sm font-medium text-slate-200">성별</span>
-          <select
-            defaultValue="여성"
-            className="w-full rounded-md border border-white/10 bg-slate-900 px-3 py-3 text-white outline-none focus:border-emerald-300"
-          >
-            {genders.map((gender) => (
-              <option key={gender} value={gender}>
-                {gender}
-              </option>
-            ))}
-          </select>
-        </label>
-
-        <button
-          type="button"
-          className="rounded-md bg-emerald-400 px-4 py-3 font-semibold text-slate-950 hover:bg-emerald-300"
-        >
-          온보딩 답변 저장
-        </button>
+            {updateProfileMutation.isPending ? '저장 중...' : '저장'}
+          </button>
+        </div>
       </form>
 
       <section className="space-y-4 rounded-lg border border-white/10 bg-white/3 p-6">
-        <div className="space-y-1">
-          <h2 className="text-lg font-semibold text-white">히스토리</h2>
-          <p className="text-sm text-slate-400">
-            플레이했던 시나리오와 결말 수집도를 표시할 예정인 mock 영역입니다.
-          </p>
+        <div className="flex gap-2 border-b border-white/10 pb-3" role="tablist" aria-label="마이페이지 탭">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={activeTab === 'history'}
+            onClick={() => setActiveTab('history')}
+            className={`rounded-md px-3 py-2 text-sm font-semibold ${
+              activeTab === 'history'
+                ? 'bg-emerald-400 text-slate-950'
+                : 'bg-slate-900 text-slate-300 hover:text-white'
+            }`}
+          >
+            히스토리
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={activeTab === 'achievements'}
+            onClick={() => setActiveTab('achievements')}
+            className={`rounded-md px-3 py-2 text-sm font-semibold ${
+              activeTab === 'achievements'
+                ? 'bg-emerald-400 text-slate-950'
+                : 'bg-slate-900 text-slate-300 hover:text-white'
+            }`}
+          >
+            업적
+          </button>
         </div>
 
-        <div className="space-y-3">
-          {scenarioHistory.map((scenario) => {
-            const collectionRate = Math.round(
-              (scenario.endingsCollected / scenario.endingsTotal) * 100,
-            )
+        {activeTab === 'history' ? (
+          <div role="tabpanel" className="space-y-3">
+            {scenarioHistory.map((scenario) => {
+              const collectionRate = Math.round(
+                (scenario.endingsCollected / scenario.endingsTotal) * 100,
+              )
 
-            return (
-              <article key={scenario.title} className="rounded-md border border-white/10 bg-slate-900 p-4">
-                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                  <div>
-                    <h3 className="font-semibold text-white">{scenario.title}</h3>
-                    <p className="mt-1 text-sm text-slate-400">
-                      최근 플레이 {scenario.lastPlayedAt} · {scenario.result}
-                    </p>
+              return (
+                <article
+                  key={scenario.title}
+                  aria-disabled="true"
+                  className="relative rounded-md border border-white/10 bg-slate-900 p-4 opacity-65"
+                >
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                      <h3 className="font-semibold text-white">{scenario.title}</h3>
+                      <p className="mt-1 text-sm text-slate-400">
+                        최근 플레이 {scenario.lastPlayedAt} · {scenario.result}
+                      </p>
+                    </div>
+                    <span className="w-fit rounded-md bg-slate-800 px-2 py-1 text-xs font-medium text-slate-300">
+                      Coming soon
+                    </span>
                   </div>
-                  <span className="w-fit rounded-md bg-emerald-300/10 px-2 py-1 text-xs font-medium text-emerald-300">
-                    결말 {scenario.endingsCollected}/{scenario.endingsTotal}
-                  </span>
-                </div>
 
-                <div className="mt-4 space-y-2">
-                  <div className="flex items-center justify-between text-xs text-slate-400">
-                    <span>결말 수집도</span>
-                    <span>{collectionRate}%</span>
+                  <div className="mt-4 space-y-2">
+                    <div className="flex items-center justify-between text-xs text-slate-400">
+                      <span>결말 수집도</span>
+                      <span>{collectionRate}%</span>
+                    </div>
+                    <div className="h-2 overflow-hidden rounded-full bg-slate-800">
+                      <div
+                        className="h-full rounded-full bg-slate-600"
+                        style={{ width: `${collectionRate}%` }}
+                      />
+                    </div>
                   </div>
-                  <div className="h-2 overflow-hidden rounded-full bg-slate-800">
-                    <div className="h-full rounded-full bg-emerald-400" style={{ width: `${collectionRate}%` }} />
-                  </div>
-                </div>
+                </article>
+              )
+            })}
+          </div>
+        ) : (
+          <div role="tabpanel" className="grid gap-3 md:grid-cols-3">
+            {achievements.map((achievement) => (
+              <article
+                key={achievement.title}
+                aria-disabled="true"
+                className="rounded-md border border-dashed border-white/15 bg-slate-900 p-4 opacity-65"
+              >
+                <span className="rounded-md bg-slate-800 px-2 py-1 text-xs font-medium text-slate-300">
+                  Coming soon
+                </span>
+                <h3 className="mt-4 font-semibold text-white">{achievement.title}</h3>
+                <p className="mt-2 text-sm leading-6 text-slate-400">{achievement.description}</p>
               </article>
-            )
-          })}
-        </div>
+            ))}
+          </div>
+        )}
       </section>
 
-      <section className="rounded-lg border border-dashed border-white/15 p-5">
-        <h2 className="text-lg font-semibold text-white">업적</h2>
-        <p className="mt-2 text-sm text-slate-400">추후 achievement 도메인 연동 시 이 영역에 표시됩니다.</p>
+      <section className="rounded-lg border border-red-300/30 bg-red-500/8 p-6">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-red-100">계정 삭제</h2>
+            <p className="mt-2 text-sm leading-6 text-red-100/80">
+              탈퇴하면 계정과 활동 기록이 영구 삭제되며 복구할 수 없습니다.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => setIsWithdrawDialogOpen(true)}
+            className="rounded-md bg-red-400 px-4 py-3 text-sm font-semibold text-slate-950 transition hover:bg-red-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-200"
+          >
+            회원 탈퇴
+          </button>
+        </div>
       </section>
     </section>
   )

--- a/apps/frontend/src/features/user/pages/MyPage.tsx
+++ b/apps/frontend/src/features/user/pages/MyPage.tsx
@@ -124,7 +124,7 @@ const hasProfileChanges = (profile: UserProfile, form: ProfileForm) =>
 
 function ProfileSkeleton() {
   return (
-    <div className="space-y-5 rounded-lg border border-white/10 bg-white/3 p-6">
+    <div className="space-y-5 rounded-lg border border-white/10 bg-white/5 p-6">
       <div className="flex items-center gap-4">
         <div className="size-16 animate-pulse rounded-full bg-slate-800" />
         <div className="space-y-3">
@@ -170,7 +170,7 @@ function WithdrawDialog({ isSubmitting, onCancel, onConfirm }: WithdrawDialogPro
       const dialog = dialogRef.current
       const focusableElements = Array.from(
         dialog?.querySelectorAll<HTMLElement>(focusableSelector) ?? [],
-      ).filter((element) => !element.hasAttribute('disabled') && !element.getAttribute('aria-hidden'))
+      ).filter((element) => element.getAttribute('aria-hidden') !== 'true')
 
       if (!dialog || focusableElements.length === 0) {
         event.preventDefault()
@@ -394,7 +394,7 @@ export function MyPage() {
         <p className="text-slate-300">내 계정과 맞춤 훈련 설정을 확인합니다.</p>
       </div>
 
-      <section className="rounded-lg border border-white/10 bg-white/3 p-6">
+      <section className="rounded-lg border border-white/10 bg-white/5 p-6">
         <div className="flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-4">
             <div className="flex size-16 items-center justify-center rounded-full border border-emerald-300/40 bg-emerald-300/10 text-2xl font-semibold text-emerald-200">
@@ -419,7 +419,7 @@ export function MyPage() {
         </div>
       </section>
 
-      <form className="space-y-5 rounded-lg border border-white/10 bg-white/3 p-6" onSubmit={handleSubmit}>
+      <form className="space-y-5 rounded-lg border border-white/10 bg-white/5 p-6" onSubmit={handleSubmit}>
         <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
           <div>
             <h2 className="text-lg font-semibold text-white">회원 정보</h2>
@@ -517,7 +517,7 @@ export function MyPage() {
         </div>
       </form>
 
-      <section className="space-y-4 rounded-lg border border-white/10 bg-white/3 p-6">
+      <section className="space-y-4 rounded-lg border border-white/10 bg-white/5 p-6">
         <div className="flex gap-2 border-b border-white/10 pb-3" role="tablist" aria-label="마이페이지 탭">
           <button
             type="button"
@@ -607,7 +607,7 @@ export function MyPage() {
         )}
       </section>
 
-      <section className="rounded-lg border border-red-300/30 bg-red-500/8 p-6">
+      <section className="rounded-lg border border-red-300/30 bg-red-500/10 p-6">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h2 className="text-lg font-semibold text-red-100">계정 삭제</h2>

--- a/apps/frontend/src/features/user/queryKeys.ts
+++ b/apps/frontend/src/features/user/queryKeys.ts
@@ -1,0 +1,4 @@
+export const userKeys = {
+  all: ['user'] as const,
+  me: () => [...userKeys.all, 'me'] as const,
+}

--- a/apps/frontend/src/features/user/types.ts
+++ b/apps/frontend/src/features/user/types.ts
@@ -97,6 +97,30 @@ export type OnboardingResponse = {
   role: UserRole
 }
 
+export type UserProfile = {
+  name: string
+  email: string
+  occupation: Occupation | null
+  gender: Gender | null
+  ageGroup: AgeGroup | null
+}
+
+export type UpdateProfileRequest = {
+  occupation: Occupation
+  gender: Gender
+  ageGroup: AgeGroup
+}
+
+export type UpdateProfileResponse = {
+  message: string
+}
+
+export type WithdrawalResponse = {
+  message: string
+  scheduledAt: string
+  status: string
+}
+
 export type Option<Value extends string> = {
   value: Value
   label: string

--- a/apps/frontend/src/routes/ProtectedRoute.tsx
+++ b/apps/frontend/src/routes/ProtectedRoute.tsx
@@ -2,26 +2,44 @@ import type { ReactNode } from 'react'
 import { Navigate, useLocation } from 'react-router-dom'
 
 import { useAuthStore } from '@/features/auth/store'
+import type { UserRole } from '@/features/auth/types'
 
 type ProtectedRouteProps = {
   children: ReactNode
+  allowedRoles?: UserRole[]
 }
 
-export function ProtectedRoute({ children }: ProtectedRouteProps) {
+const getRedirectPathForRole = (role: UserRole) => {
+  if (role === 'GUEST') {
+    return '/onboarding'
+  }
+
+  if (role === 'ADMIN') {
+    return '/'
+  }
+
+  return '/mypage'
+}
+
+export function ProtectedRoute({ allowedRoles, children }: ProtectedRouteProps) {
   const location = useLocation()
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
-  const user = useAuthStore((state) => state.user)
+  const role = useAuthStore((state) => state.role)
 
   if (!isAuthenticated) {
     return <Navigate to="/login" replace state={{ from: location }} />
   }
 
-  if (!user) {
+  if (!role) {
     return (
       <div className="py-16 text-center text-sm text-slate-300">
         인증 상태를 확인하고 있습니다.
       </div>
     )
+  }
+
+  if (allowedRoles && !allowedRoles.includes(role)) {
+    return <Navigate to={getRedirectPathForRole(role)} replace />
   }
 
   return children


### PR DESCRIPTION
## 관련 이슈
Closes #41 

## 작업 내용
- 마이페이지 UX를 백엔드 사용자 API와 연동 
- 로비/마이페이지에서 실제 회원 정보를 사용하도록 개선 
- 회원 정보 수정, role 기반 라우트 가드, 회원 탈퇴 플로우를 추가
- 히스토리와 업적은 Coming soon 상태로 비활성화했습니다.

## 변경 사항
- GET /api/v1/users/me, PATCH /api/v1/users/me, POST /api/v1/users/me/withdrawal API 및 React Query 훅 추가
- 마이페이지에서 이름/이메일 표시, 직업/연령대/성별 수정, 저장 성공/실패 토스트 처리
- 히스토리/업적 등 미지원 영역을 비활성 UI로 변경
- 회원 탈퇴 위험 영역 및 비복구 안내 다이얼로그 추가
- 탈퇴 성공 시 인증 정보와 React Query 캐시를 정리하고 로그인 페이지로 이동
- USER/GUEST role 기반 라우트 가드 추가 및 role hydration 보강

## 체크리스트
- [x] 코드 포맷팅(Checkstyle, Lint 등)을 적용하였는가?
- [x] 테스트 코드를 작성하고 통과했는가?
- [x] 불필요한 console.log / print 등을 제거했는가?
- [x] 로컬 테스트를 완료했는가?
- [x] 관련 서비스 동작을 확인했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자 프로필 조회 및 편집 기능 추가
  * 계정 탈퇴 기능 및 확인 대화상자 구현
  * 앱 전반에 맞춤형 인사말 메시지 추가
  * 역할 기반 경로 접근 제어 강화
  * 로그인 페이지에 탈퇴 완료 알림 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->