### PR TITLE
[FEAT] 인증/인가 실패 응답 ApiResponse 표준화 (#57)

### DIFF
--- a/apps/backend/src/main/java/com/sos/backend/global/auth/JwtAccessDeniedHandler.java
+++ b/apps/backend/src/main/java/com/sos/backend/global/auth/JwtAccessDeniedHandler.java
@@ -1,0 +1,33 @@
+package com.sos.backend.global.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sos.backend.global.common.exception.ErrorCode;
+import com.sos.backend.global.common.response.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
+
+        ErrorCode errorCode = ErrorCode.FORBIDDEN;
+
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+        objectMapper.writeValue(response.getWriter(), ApiResponse.error(errorCode));
+    }
+}

--- a/apps/backend/src/main/java/com/sos/backend/global/auth/JwtAuthenticationEntryPoint.java
+++ b/apps/backend/src/main/java/com/sos/backend/global/auth/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,37 @@
+package com.sos.backend.global.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sos.backend.global.common.exception.ErrorCode;
+import com.sos.backend.global.common.response.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    // JwtFilter가 토큰 실패 사유를 담는 키 (같은 패키지라 필터가 그대로 참조)
+    public static final String AUTH_ERROR_ATTRIBUTE = "authError";
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+
+        Object stashed = request.getAttribute(AUTH_ERROR_ATTRIBUTE);
+        ErrorCode errorCode = (stashed instanceof ErrorCode ec) ? ec : ErrorCode.UNAUTHORIZED;
+
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+        objectMapper.writeValue(response.getWriter(), ApiResponse.error(errorCode));
+    }
+}

--- a/apps/backend/src/main/java/com/sos/backend/global/auth/JwtFilter.java
+++ b/apps/backend/src/main/java/com/sos/backend/global/auth/JwtFilter.java
@@ -1,6 +1,7 @@
 package com.sos.backend.global.auth;
 
 import com.sos.backend.domain.user.enums.UserStatus;
+import com.sos.backend.global.common.exception.CustomException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -27,21 +28,26 @@ public class JwtFilter extends OncePerRequestFilter {
 
         String token = resolveToken(request);
 
-        if (token != null && jwtProvider.validateToken(token)) {
-            Long userId = jwtProvider.getUserId(token);
-            String email = jwtProvider.getEmail(token);
-            UserStatus userStatus = userStatusCacheService.getStatus(userId);
+        if (token != null) {
+            try {
+                jwtProvider.validateOrThrow(token);
 
-            if (userStatus == UserStatus.WITHDRAWAL_PENDING || userStatus == UserStatus.WITHDRAWN) {
-                filterChain.doFilter(request, response);
-                return;
+                Long userId = jwtProvider.getUserId(token);
+                String email = jwtProvider.getEmail(token);
+                UserStatus userStatus = userStatusCacheService.getStatus(userId);
+
+                // 탈퇴/탈퇴대기 유저는 인증을 걸지 않음 (기존 동작 유지)
+                if (userStatus != UserStatus.WITHDRAWAL_PENDING
+                    && userStatus != UserStatus.WITHDRAWN) {
+                    UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(
+                            userId, email, Collections.emptyList());
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
+            } catch (CustomException e) {
+                // 사유 stash → entry point가 읽어 ApiResponse 401 생성
+                request.setAttribute(JwtAuthenticationEntryPoint.AUTH_ERROR_ATTRIBUTE, e.getErrorCode());
             }
-
-            UsernamePasswordAuthenticationToken authentication =
-                new UsernamePasswordAuthenticationToken(
-                    userId, email, Collections.emptyList());
-
-            SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 
         filterChain.doFilter(request, response);

--- a/apps/backend/src/main/java/com/sos/backend/global/auth/JwtProvider.java
+++ b/apps/backend/src/main/java/com/sos/backend/global/auth/JwtProvider.java
@@ -84,16 +84,6 @@ public class JwtProvider {
             .toLocalDateTime();
     }
 
-    // 토큰 유효성 검증
-    public boolean validateToken(String token) {
-        try {
-            getClaims(token);
-            return true;
-        } catch (JwtException | IllegalArgumentException e) {
-            return false;
-        }
-    }
-
     // 토큰 유효성 검증하고, 실패 시 만료/위조 구분된 CustomException throw
     public void validateOrThrow(String token) {
         try {

--- a/apps/backend/src/main/java/com/sos/backend/global/common/config/SecurityConfig.java
+++ b/apps/backend/src/main/java/com/sos/backend/global/common/config/SecurityConfig.java
@@ -1,9 +1,8 @@
 package com.sos.backend.global.common.config;
 
 import com.sos.backend.domain.auth.PasswordProperties;
-import com.sos.backend.global.auth.JwtFilter;
-import com.sos.backend.global.auth.JwtProvider;
-import com.sos.backend.global.auth.UserStatusCacheService;
+import com.sos.backend.global.auth.*;
+
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,8 +21,6 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import jakarta.servlet.http.HttpServletResponse;
-
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
@@ -32,6 +29,8 @@ public class SecurityConfig {
     private final JwtProvider jwtProvider;
     private final PasswordProperties passwordProperties;
     private final UserStatusCacheService userStatusCacheService;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
     @Value("${cors.allowed-origins:http://localhost:5173}")
     private List<String> allowedOrigins;
@@ -64,9 +63,8 @@ public class SecurityConfig {
                 .anyRequest().authenticated()
             )
             .exceptionHandling(ex -> ex
-                .authenticationEntryPoint((request, response, authException) ->
-                    response.sendError(HttpServletResponse.SC_UNAUTHORIZED))
-            )
+                .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                .accessDeniedHandler(jwtAccessDeniedHandler))
             .addFilterBefore(new JwtFilter(jwtProvider, userStatusCacheService),
                 UsernamePasswordAuthenticationFilter.class);
 


### PR DESCRIPTION
## 관련 이슈
Closes #57 

## 작업 내용
필터/시큐리티 단계에서 발생하는 401·403 응답을 ApiResponse 형식으로 표준화.
기존엔 미인증 401이 `sendError`로 컨테이너 기본 에러(`{timestamp,status,error,path}`)로 나가
앱의 다른 에러 응답(ApiResponse)과 형식이 갈렸음.

## 변경 사항
- [x] `JwtAuthenticationEntryPoint` 추가 — 401을 ApiResponse로 응답, stash된 사유(EXPIRED/INVALID) 반영, 없으면 UNAUTHORIZED
- [x] `JwtAccessDeniedHandler` 추가 — 403을 ApiResponse로 응답
- [x] `SecurityConfig.exceptionHandling`에 두 핸들러 등록, 기존 인라인 `sendError` 스텁 + unused import 제거
- [x] `JwtFilter` — `validateToken` → `validateOrThrow` + try/catch로 사유 stash (토큰 없음/무효/만료 구분)
- [x] `JwtProvider`에서 미사용 `validateToken`(boolean) 제거

## 동작
| 상황 | 응답 |
|---|---|
| 토큰 없음 | 401 `UNAUTHORIZED` |
| 토큰 무효 | 401 `INVALID_TOKEN` |
| 토큰 만료 | 401 `EXPIRED_TOKEN` |
| public endpoint + 나쁜 토큰 | 정상 처리 (regression 없음) |


## 체크리스트
- [x] 코드 포맷팅(Checkstyle, Lint 등)을 적용하였는가?
- [ ] 테스트 코드를 작성하고 통과했는가?
- [x] 불필요한 console.log / print 등을 제거했는가?
- [x] 로컬 테스트를 완료했는가?
- [x] 관련 서비스 동작을 확인했는가?

## 테스트
<img width="917" height="299" alt="스크린샷 2026-06-03 오후 7 23 36" src="https://github.com/user-attachments/assets/e1cc8e4d-777f-4808-a361-261cf90b80bb" />
<img width="980" height="316" alt="스크린샷 2026-06-03 오후 7 23 45" src="https://github.com/user-attachments/assets/633eeb4a-b00e-4e91-8fb8-016683e1794f" />

## 리뷰 포인트
- 이 표준화는 auth 도메인뿐 아니라 **모든 인증 필요 endpoint에 전역 적용** (user 도메인 포함)
- `JwtAccessDeniedHandler`는 현재 role 기반 라우트가 없어 **실제 트리거 없음(dormant)** — 추후 인가 규칙 대비 사전 배치
- 탈퇴/탈퇴대기 유저는 기존 동작 유지(인증 안 걺 → 일반 401). 별도 사유 응답은 범위 외
- 필터 `catch(CustomException)`이 `getStatus()`의 CustomException도 포섭 → 유효 토큰+유저 부재 희귀 케이스에서 500 대신 graceful 응답

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 인증 실패 및 권한 거부 시 통일된 오류 응답 처리 추가
  * JSON 형식의 일관된 오류 응답으로 API 안정성 향상

* **개선사항**
  * 토큰 검증 로직 개선으로 만료된 토큰과 유효하지 않은 토큰을 구분하여 처리
  * 보안 예외 처리 체계 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->