### PR TITLE
[DOCS] Auth Swagger 어노테이션 + SecurityRequirement 정비 (#60)

### DIFF
--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/controller/AuthController.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/controller/AuthController.java
@@ -151,6 +151,12 @@ public class AuthController {
     }
 
     @Operation(summary = "전체 로그아웃", description = "해당 사용자의 모든 Refresh Token을 폐기한다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "전체 로그아웃 성공 (모든 Refresh Token 폐기)"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401",
+            description = "Access Token 무효/만료/미첨부 (UNAUTHORIZED / INVALID_TOKEN / EXPIRED_TOKEN)",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class)))
+    })
     @PostMapping("/logout/all")
     @SecurityRequirement(name = "bearerAuth")
     public ApiResponse<Void> logoutAll(@AuthenticationPrincipal Long userId) {

--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/controller/AuthController.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/controller/AuthController.java
@@ -8,7 +8,9 @@ import com.sos.backend.domain.auth.dto.response.SignupResponse;
 import com.sos.backend.domain.auth.service.AuthService;
 import com.sos.backend.domain.auth.service.EmailVerificationService;
 import com.sos.backend.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -18,23 +20,27 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
+@Tag(name = "Auth", description = "인증 관련 API (이메일 인증, 회원가입, 로그인, 토큰 관리)")
 public class AuthController {
 
     private final EmailVerificationService emailVerificationService;
     private final AuthService authService;
 
+    @Operation(summary = "이메일 인증 코드 전송", description = "email과 purpose(SIGNUP/PASSWORD_RESET)를 받아 6자리 인증 코드를 메일로 발송한다.")
     @PostMapping("/email/send")
     public ApiResponse<Void> sendEmailCode(@Valid @RequestBody EmailSendRequest request) {
         emailVerificationService.send(request.email(), request.purpose());
         return ApiResponse.success(null);
     }
 
+    @Operation(summary = "이메일 인증 코드 검증", description = "인증 코드를 검증하고, 성공 시 단기 verification_token(5분 유효)을 발급한다.")
     @PostMapping("/email/verify")
     public ApiResponse<EmailVerifyResponse> verifyEmailCode(@Valid @RequestBody EmailVerifyRequest request) {
         String verificationToken = emailVerificationService.verify(request.email(), request.code(), request.purpose());
         return ApiResponse.success(new EmailVerifyResponse(verificationToken));
     }
 
+    @Operation(summary = "자체 회원가입", description = "email, password, name, verification_token으로 회원가입을 처리한다.")
     @PostMapping("/signup")
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<SignupResponse> signup(@Valid @RequestBody SignupRequest request) {
@@ -42,18 +48,21 @@ public class AuthController {
         return ApiResponse.success(response);
     }
 
+    @Operation(summary = "자체 로그인", description = "email, password로 로그인하고 Access Token과 Refresh Token을 발급한다.")
     @PostMapping("/login")
     public ApiResponse<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
         LoginResponse response = authService.login(request);
         return ApiResponse.success(response);
     }
 
+    @Operation(summary = "토큰 갱신", description = "Refresh Token으로 새 Access Token을 발급한다. Refresh Token Rotation이 적용된다.")
     @PostMapping("/refresh")
     public ApiResponse<RefreshResponse> refresh(@Valid @RequestBody RefreshRequest request) {
         RefreshResponse response = authService.refresh(request);
         return ApiResponse.success(response);
     }
 
+    @Operation(summary = "로그아웃", description = "현재 기기의 Refresh Token을 폐기한다(revoked=true). Access Token은 만료까지 유효.")
     @PostMapping("/logout")
     @SecurityRequirement(name = "bearerAuth")
     public ApiResponse<Void> logout(
@@ -64,6 +73,7 @@ public class AuthController {
         return ApiResponse.success(null);
     }
 
+    @Operation(summary = "전체 로그아웃", description = "해당 사용자의 모든 Refresh Token을 폐기한다.")
     @PostMapping("/logout/all")
     @SecurityRequirement(name = "bearerAuth")
     public ApiResponse<Void> logoutAll(@AuthenticationPrincipal Long userId) {

--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/controller/AuthController.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/controller/AuthController.java
@@ -9,6 +9,10 @@ import com.sos.backend.domain.auth.service.AuthService;
 import com.sos.backend.domain.auth.service.EmailVerificationService;
 import com.sos.backend.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -27,6 +31,15 @@ public class AuthController {
     private final AuthService authService;
 
     @Operation(summary = "이메일 인증 코드 전송", description = "email과 purpose(SIGNUP/PASSWORD_RESET)를 받아 6자리 인증 코드를 메일로 발송한다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "인증 코드 발송 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400",
+            description = "요청 검증 실패 (VALIDATION_ERROR)",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429",
+            description = "재발송 쿨다운(EMAIL_VERIFICATION_COOLDOWN) / 일일 한도 초과(EMAIL_VERIFICATION_DAILY_LIMIT)",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class)))
+    })
     @PostMapping("/email/send")
     public ApiResponse<Void> sendEmailCode(@Valid @RequestBody EmailSendRequest request) {
         emailVerificationService.send(request.email(), request.purpose());
@@ -34,6 +47,12 @@ public class AuthController {
     }
 
     @Operation(summary = "이메일 인증 코드 검증", description = "인증 코드를 검증하고, 성공 시 단기 verification_token(5분 유효)을 발급한다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "인증 성공, verification_token 발급"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400",
+            description = "요청 검증 실패(VALIDATION_ERROR) / 코드 불일치·만료(EMAIL_VERIFICATION_CODE_INVALID) / 시도 초과(EMAIL_VERIFICATION_ATTEMPTS_EXCEEDED)",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class)))
+    })
     @PostMapping("/email/verify")
     public ApiResponse<EmailVerifyResponse> verifyEmailCode(@Valid @RequestBody EmailVerifyRequest request) {
         String verificationToken = emailVerificationService.verify(request.email(), request.code(), request.purpose());
@@ -41,6 +60,20 @@ public class AuthController {
     }
 
     @Operation(summary = "자체 회원가입", description = "email, password, name, verification_token으로 회원가입을 처리한다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "회원가입 성공 (자동 로그인 토큰 발급)"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400",
+            description = "요청 검증 실패(VALIDATION_ERROR) / 비밀번호 길이 위반(INVALID_PASSWORD_LENGTH)",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class),
+                examples = @ExampleObject(name = "VALIDATION_ERROR", value = """
+                {"error":{"code":"VALIDATION_ERROR","message":"입력값이 올바르지 않습니다","fieldInfo":[{"field":"email","message":"올바른 이메일 형식이 아닙니다"}]},"meta":{"timestamp":"2026-06-04T12:00:00"}}"""))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401",
+            description = "verification_token 무효/만료/purpose 불일치 (INVALID_TOKEN / EXPIRED_TOKEN)",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409",
+            description = "이미 사용 중인 이메일 (EMAIL_ALREADY_EXISTS)",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class)))
+    })
     @PostMapping("/signup")
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<SignupResponse> signup(@Valid @RequestBody SignupRequest request) {
@@ -49,6 +82,17 @@ public class AuthController {
     }
 
     @Operation(summary = "자체 로그인", description = "email, password로 로그인하고 Access Token과 Refresh Token을 발급한다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공 (Access/Refresh Token 발급)"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400",
+            description = "요청 검증 실패 (VALIDATION_ERROR)",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401",
+            description = "이메일/비밀번호 불일치 또는 비활성 계정 (INVALID_CREDENTIALS) — 보안상 사유 미구분",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class),
+                examples = @ExampleObject(name = "INVALID_CREDENTIALS", value = """
+                {"error":{"code":"INVALID_CREDENTIALS","message":"이메일 또는 비밀번호가 올바르지 않습니다"},"meta":{"timestamp":"2026-06-04T12:00:00"}}""")))
+    })
     @PostMapping("/login")
     public ApiResponse<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
         LoginResponse response = authService.login(request);
@@ -56,6 +100,24 @@ public class AuthController {
     }
 
     @Operation(summary = "토큰 갱신", description = "Refresh Token으로 새 Access Token을 발급한다. Refresh Token Rotation이 적용된다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "토큰 갱신 성공 (Rotation 적용)"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400",
+            description = "요청 검증 실패 (VALIDATION_ERROR)",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401",
+            description = "Refresh Token 무효/만료/재사용 감지 (INVALID_TOKEN / EXPIRED_TOKEN)",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class),
+                examples = {
+                    @ExampleObject(name = "EXPIRED_TOKEN", value = """
+                    {"error":{"code":"EXPIRED_TOKEN","message":"만료된 토큰입니다"},"meta":{"timestamp":"2026-06-04T12:00:00"}}"""),
+                    @ExampleObject(name = "INVALID_TOKEN", value = """
+                    {"error":{"code":"INVALID_TOKEN","message":"유효하지 않은 토큰입니다"},"meta":{"timestamp":"2026-06-04T12:00:00"}}""")
+                })),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404",
+            description = "토큰의 사용자를 찾을 수 없음 (USER_NOT_FOUND)",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class)))
+    })
     @PostMapping("/refresh")
     public ApiResponse<RefreshResponse> refresh(@Valid @RequestBody RefreshRequest request) {
         RefreshResponse response = authService.refresh(request);
@@ -63,6 +125,21 @@ public class AuthController {
     }
 
     @Operation(summary = "로그아웃", description = "현재 기기의 Refresh Token을 폐기한다(revoked=true). Access Token은 만료까지 유효.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그아웃 성공 (현재 기기 Refresh Token 폐기)"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400",
+            description = "요청 검증 실패 (VALIDATION_ERROR)",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401",
+            description = "Access Token 무효/만료/미첨부 (UNAUTHORIZED / INVALID_TOKEN / EXPIRED_TOKEN) 또는 본문 Refresh Token 무효 (INVALID_TOKEN / EXPIRED_TOKEN)",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class),
+                examples = {
+                    @ExampleObject(name = "UNAUTHORIZED (토큰 미첨부)", value = """
+                    {"error":{"code":"UNAUTHORIZED","message":"인증이 필요합니다"},"meta":{"timestamp":"2026-06-04T12:00:00"}}"""),
+                    @ExampleObject(name = "EXPIRED_TOKEN", value = """
+                    {"error":{"code":"EXPIRED_TOKEN","message":"만료된 토큰입니다"},"meta":{"timestamp":"2026-06-04T12:00:00"}}""")
+                }))
+    })
     @PostMapping("/logout")
     @SecurityRequirement(name = "bearerAuth")
     public ApiResponse<Void> logout(

--- a/apps/backend/src/main/java/com/sos/backend/domain/auth/controller/AuthController.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/auth/controller/AuthController.java
@@ -8,6 +8,7 @@ import com.sos.backend.domain.auth.dto.response.SignupResponse;
 import com.sos.backend.domain.auth.service.AuthService;
 import com.sos.backend.domain.auth.service.EmailVerificationService;
 import com.sos.backend.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -54,6 +55,7 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
+    @SecurityRequirement(name = "bearerAuth")
     public ApiResponse<Void> logout(
         @Valid @RequestBody LogoutRequest request,
         @AuthenticationPrincipal Long userId
@@ -63,6 +65,7 @@ public class AuthController {
     }
 
     @PostMapping("/logout/all")
+    @SecurityRequirement(name = "bearerAuth")
     public ApiResponse<Void> logoutAll(@AuthenticationPrincipal Long userId) {
         authService.logoutAll(userId);
         return ApiResponse.success(null);

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/controller/UserController.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/controller/UserController.java
@@ -12,6 +12,7 @@ import com.sos.backend.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/users/me")
+@SecurityRequirement(name = "bearerAuth")
 @Tag(name = "User", description = "내 정보 조회/수정 및 온보딩 API")
 public class UserController {
 

--- a/apps/backend/src/main/java/com/sos/backend/global/common/config/SwaggerConfig.java
+++ b/apps/backend/src/main/java/com/sos/backend/global/common/config/SwaggerConfig.java
@@ -2,7 +2,6 @@ package com.sos.backend.global.common.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,7 +12,6 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
-            .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
             .components(new io.swagger.v3.oas.models.Components()
                 .addSecuritySchemes("bearerAuth", new SecurityScheme()
                     .name("Authorization")


### PR DESCRIPTION
## 관련 이슈
Closes #60 

## 작업 내용
- SwaggerConfig: 전역 `addSecurityItem` 제거 (SecurityScheme 정의는 유지)
- 보호 endpoint(logout, logout/all)에 메서드 레벨 `@SecurityRequirement`
- UserController 클래스 레벨 `@SecurityRequirement` (전역 제거에 따른 보호 표시 보존)
- Auth 7개 endpoint에 `@Tag` / `@Operation`
- endpoint별 `@ApiResponses` (성공 + 핵심 실패), 401 등에 ApiResponse 바디 스키마 + 예시

## 결정 사항
- SecurityRequirement: 전역 → 보호 endpoint 개별 적용 (springdoc 공식 패턴, public 자물쇠 오표기 방지)
- @ApiResponses: 핵심만 (성공 + endpoint별 의미 있는 실패)
- 403은 auth endpoint에 해당 없음 (인증만 요구, 권한 요구 X) → 401만 문서화

## 체크리스트
- [x] 코드 포맷팅(Checkstyle, Lint 등)을 적용하였는가?
- [ ] 테스트 코드를 작성하고 통과했는가?
- [x] 불필요한 console.log / print 등을 제거했는가?
- [x] 로컬 테스트를 완료했는가?
- [x] 관련 서비스 동작을 확인했는가?

## 테스트
swagger-ui(/swagger-ui/index.html) 확인:
- public 5개(email/send·verify, signup, login, refresh) 자물쇠 없음 / 보호 2개(logout, logout/all) + User endpoint 자물쇠 O
- Auth 그룹핑, 각 endpoint @Operation summary·description 노출
- 각 endpoint Responses에 상태코드 + 설명, 401·검증 예시 JSON 렌더링

## 스크린샷
UI 변경이 있다면 첨부해주세요.

## 리뷰 포인트
- swagger @ApiResponse는 프로젝트 ApiResponse와 이름 충돌이라 FQN으로 작성 (컨테이너 @ApiResponses만 import)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 문서화

* API 엔드포인트에 대한 Swagger/OpenAPI 문서화 강화로 개발자 경험 개선
* 인증 관련 엔드포인트의 보안 요구사항 및 응답 코드별 설명 추가
* 각 API 응답의 스키마 및 예시 데이터 명시
* Bearer 토큰 기반 인증 스키마 설정 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->