### PR TITLE
[FEAT] survey기반 시나리오 추천 구현(#61)

### DIFF
--- a/apps/ai-pipeline/app/data/scenarios/scenario_3322ab81.json
+++ b/apps/ai-pipeline/app/data/scenarios/scenario_3322ab81.json
@@ -10326,7 +10326,12 @@
   "total_endings": 243,
   "total_good_endings": 137,
   "total_bad_endings": 106,
-  "tags": [],
+  "tags": [
+    "online:government",
+    "online:online_shopping",
+    "economic:online_shopping",
+    "financial:mobile_banking"
+  ],
   "created_at": "2026-05-26T03:36:41.770456Z",
   "updated_at": "2026-05-26T04:18:51.696222Z",
   "ending_categories": {

--- a/apps/ai-pipeline/app/data/scenarios/scenario_930938c1.json
+++ b/apps/ai-pipeline/app/data/scenarios/scenario_930938c1.json
@@ -10285,7 +10285,12 @@
   "total_endings": 241,
   "total_good_endings": 132,
   "total_bad_endings": 109,
-  "tags": [],
+  "tags": [
+    "economic:investment",
+    "financial:mobile_banking",
+    "financial:crypto",
+    "communicate:phone"
+  ],
   "created_at": "2026-06-03T03:44:05.000368Z",
   "updated_at": "2026-06-03T06:56:23.793014Z",
   "ending_categories": {

--- a/apps/ai-pipeline/app/data/scenarios/scenario_952bc118.json
+++ b/apps/ai-pipeline/app/data/scenarios/scenario_952bc118.json
@@ -10390,7 +10390,11 @@
   "total_endings": 243,
   "total_good_endings": 134,
   "total_bad_endings": 109,
-  "tags": [],
+  "tags": [
+    "communicate:sms",
+    "online:government",
+    "financial:mobile_banking"
+  ],
   "created_at": "2026-06-02T04:05:26.260355Z",
   "updated_at": "2026-06-02T05:25:57.247338Z",
   "ending_categories": {

--- a/apps/ai-pipeline/app/data/scenarios/scenario_a35ecc62.json
+++ b/apps/ai-pipeline/app/data/scenarios/scenario_a35ecc62.json
@@ -10460,7 +10460,11 @@
   "total_endings": 243,
   "total_good_endings": 126,
   "total_bad_endings": 117,
-  "tags": [],
+  "tags": [
+    "occupation:self_employed",
+    "communicate:phone",
+    "financial:mobile_banking"
+  ],
   "created_at": "2026-06-02T15:44:37.615686Z",
   "updated_at": "2026-06-02T17:11:39.091101Z",
   "ending_categories": {

--- a/apps/ai-pipeline/app/data/scenarios/scenario_f166ade2.json
+++ b/apps/ai-pipeline/app/data/scenarios/scenario_f166ade2.json
@@ -10407,7 +10407,12 @@
   "total_endings": 242,
   "total_good_endings": 127,
   "total_bad_endings": 115,
-  "tags": [],
+  "tags": [
+    "communicate:messenger",
+    "communicate:sns",
+    "financial:overseas_remit",
+    "family:alone"
+  ],
   "created_at": "2026-06-03T07:37:27.310229Z",
   "updated_at": "2026-06-03T09:22:43.344289Z",
   "ending_categories": {

--- a/apps/ai-pipeline/app/data/scenarios/scenario_ff08d058.json
+++ b/apps/ai-pipeline/app/data/scenarios/scenario_ff08d058.json
@@ -10014,7 +10014,11 @@
   "total_endings": 237,
   "total_good_endings": 134,
   "total_bad_endings": 103,
-  "tags": [],
+  "tags": [
+    "communicate:email",
+    "occupation:employee",
+    "online:online_shopping"
+  ],
   "created_at": "2026-05-22T04:59:44.180299Z",
   "updated_at": "2026-05-22T05:22:34.798817Z",
   "ending_categories": {

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/dto/UserInfoResponse.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/dto/UserInfoResponse.java
@@ -1,22 +1,28 @@
 package com.sos.backend.domain.user.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sos.backend.domain.user.entity.User;
 import com.sos.backend.domain.user.entity.UserProfile;
 import com.sos.backend.domain.user.enums.AgeGroup;
+import com.sos.backend.domain.user.enums.CommunicateChannel;
+import com.sos.backend.domain.user.enums.EconomicActivity;
+import com.sos.backend.domain.user.enums.FamilyType;
+import com.sos.backend.domain.user.enums.FinancialChannel;
 import com.sos.backend.domain.user.enums.Gender;
+import com.sos.backend.domain.user.enums.OnlineActivity;
 import com.sos.backend.domain.user.enums.Occupation;
 import com.sos.backend.domain.user.enums.Role;
 import com.sos.backend.domain.user.enums.UserStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.function.Function;
 
 /**
  * 내 정보 조회 응답 (auth-boundary.md §4, ADR-006 union shape).
  *
  * 필수 (auth-boundary v1 §4): id, email, name, role, status, created_at
- * 선택 (회원가입 정보 보존): occupation, gender, ageGroup
+ * 선택 (회원가입 정보 보존): occupation, gender, ageGroup, onboarding survey fields
  */
 @Schema(description = "내 정보 조회 응답")
 public record UserInfoResponse(
@@ -45,7 +51,22 @@ public record UserInfoResponse(
     Gender gender,
 
     @Schema(description = "연령대", example = "TWENTIES")
-    AgeGroup ageGroup
+    AgeGroup ageGroup,
+
+    @Schema(description = "평소 소비 활동")
+    List<EconomicActivity> economicActivities,
+
+    @Schema(description = "자주 사용하는 연락 수단")
+    List<CommunicateChannel> communicateChannels,
+
+    @Schema(description = "최근 한 달 내 온라인 활동")
+    List<OnlineActivity> onlineActivities,
+
+    @Schema(description = "평소 금융 거래 방식")
+    List<FinancialChannel> financialChannels,
+
+    @Schema(description = "가족 구성", example = "WITH_PARENTS")
+    FamilyType familyType
 ) {
     public static UserInfoResponse from(User user, UserProfile profile) {
         return new UserInfoResponse(
@@ -57,7 +78,22 @@ public record UserInfoResponse(
             user.getCreatedAt(),
             profile != null ? profile.getOccupation() : null,
             profile != null ? profile.getGender() : null,
-            profile != null ? profile.getAgeGroup() : null
+            profile != null ? profile.getAgeGroup() : null,
+            profile != null ? toEnums(profile.getEconomicActivities(), EconomicActivity::fromCode) : List.of(),
+            profile != null ? toEnums(profile.getCommunicateChannels(), CommunicateChannel::fromCode) : List.of(),
+            profile != null ? toEnums(profile.getOnlineActivities(), OnlineActivity::fromCode) : List.of(),
+            profile != null ? toEnums(profile.getFinancialChannels(), FinancialChannel::fromCode) : List.of(),
+            profile != null ? profile.getFamilyType() : null
         );
+    }
+
+    private static <T> List<T> toEnums(List<String> codes, Function<String, T> mapper) {
+        if (codes == null) {
+            return List.of();
+        }
+        return codes.stream()
+            .filter(code -> code != null && !code.isBlank())
+            .map(mapper)
+            .toList();
     }
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/user/service/UserService.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/user/service/UserService.java
@@ -34,7 +34,7 @@ public class UserService {
 
     public UserInfoResponse getMyInfo(Long userId) {
         User user = getUser(userId);
-        UserProfile profile = getUserProfile(userId);
+        UserProfile profile = userProfileRepository.findByUserId(userId).orElse(null);
         return UserInfoResponse.from(user, profile);
     }
 

--- a/apps/backend/src/test/java/com/sos/backend/domain/user/UserMeResponseTest.java
+++ b/apps/backend/src/test/java/com/sos/backend/domain/user/UserMeResponseTest.java
@@ -2,6 +2,10 @@ package com.sos.backend.domain.user;
 
 import com.sos.backend.domain.user.entity.User;
 import com.sos.backend.domain.user.entity.UserProfile;
+import com.sos.backend.domain.user.enums.AgeGroup;
+import com.sos.backend.domain.user.enums.FamilyType;
+import com.sos.backend.domain.user.enums.Gender;
+import com.sos.backend.domain.user.enums.Occupation;
 import com.sos.backend.domain.user.enums.Role;
 import com.sos.backend.domain.user.enums.UserStatus;
 import com.sos.backend.domain.user.repository.UserProfileRepository;
@@ -17,6 +21,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Collections;
+import java.util.List;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -57,7 +62,15 @@ class UserMeResponseTest extends AbstractIntegrationTest {
 
         userProfileRepository.save(UserProfile.builder()
             .user(user)
+            .occupation(Occupation.EMPLOYEE)
+            .gender(Gender.MALE)
+            .ageGroup(AgeGroup.TWENTIES)
             .onboardingCompleted(true)
+            .economicActivities(List.of("investment"))
+            .communicateChannels(List.of("phone", "sms"))
+            .onlineActivities(List.of("government"))
+            .financialChannels(List.of("mobile_banking"))
+            .familyType(FamilyType.WITH_CHILDREN)
             .build());
 
         SecurityContextHolder.getContext().setAuthentication(
@@ -80,5 +93,21 @@ class UserMeResponseTest extends AbstractIntegrationTest {
             .andExpect(jsonPath("$.data.role").value("USER"))
             .andExpect(jsonPath("$.data.status").value("ACTIVE"))
             .andExpect(jsonPath("$.data.createdAt").exists());
+    }
+
+    @Test
+    @DisplayName("응답에 온보딩 상세 설문값이 enum 이름으로 포함된다")
+    void responseIncludesOnboardingSurveyFields() throws Exception {
+        mockMvc.perform(get("/api/v1/users/me"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.occupation").value("EMPLOYEE"))
+            .andExpect(jsonPath("$.data.gender").value("MALE"))
+            .andExpect(jsonPath("$.data.ageGroup").value("TWENTIES"))
+            .andExpect(jsonPath("$.data.economicActivities[0]").value("INVESTMENT"))
+            .andExpect(jsonPath("$.data.communicateChannels[0]").value("PHONE"))
+            .andExpect(jsonPath("$.data.communicateChannels[1]").value("SMS"))
+            .andExpect(jsonPath("$.data.onlineActivities[0]").value("GOVERNMENT"))
+            .andExpect(jsonPath("$.data.financialChannels[0]").value("MOBILE_BANKING"))
+            .andExpect(jsonPath("$.data.familyType").value("WITH_CHILDREN"));
     }
 }

--- a/apps/backend/src/test/java/com/sos/backend/domain/user/service/UserServiceTest.java
+++ b/apps/backend/src/test/java/com/sos/backend/domain/user/service/UserServiceTest.java
@@ -71,6 +71,32 @@ class UserServiceTest {
             assertThat(response.occupation()).isEqualTo(Occupation.EMPLOYEE);
             assertThat(response.gender()).isEqualTo(Gender.MALE);
             assertThat(response.ageGroup()).isEqualTo(AgeGroup.TWENTIES);
+            assertThat(response.economicActivities()).containsExactly(EconomicActivity.INVESTMENT);
+            assertThat(response.communicateChannels()).containsExactly(CommunicateChannel.PHONE, CommunicateChannel.SMS);
+            assertThat(response.onlineActivities()).containsExactly(OnlineActivity.GOVERNMENT);
+            assertThat(response.financialChannels()).containsExactly(FinancialChannel.MOBILE_BANKING);
+            assertThat(response.familyType()).isEqualTo(FamilyType.WITH_CHILDREN);
+        }
+
+        @Test
+        @DisplayName("프로필이 없으면 설문 상세값을 빈 배열과 null로 반환한다")
+        void getMyInfo_withoutProfile() {
+            Long userId = 1L;
+            User user = createUser(userId, Role.GUEST, UserStatus.ACTIVE);
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+            given(userProfileRepository.findByUserId(userId)).willReturn(Optional.empty());
+
+            UserInfoResponse response = userService.getMyInfo(userId);
+
+            assertThat(response.occupation()).isNull();
+            assertThat(response.gender()).isNull();
+            assertThat(response.ageGroup()).isNull();
+            assertThat(response.economicActivities()).isEmpty();
+            assertThat(response.communicateChannels()).isEmpty();
+            assertThat(response.onlineActivities()).isEmpty();
+            assertThat(response.financialChannels()).isEmpty();
+            assertThat(response.familyType()).isNull();
         }
 
         @Test
@@ -202,11 +228,11 @@ class UserServiceTest {
             .gender(Gender.MALE)
             .ageGroup(AgeGroup.TWENTIES)
             .onboardingCompleted(false)
-            .economicActivities(List.of())
-            .communicateChannels(List.of())
-            .onlineActivities(List.of())
-            .financialChannels(List.of())
-            .familyType(FamilyType.WITH_PARENTS)
+            .economicActivities(List.of("investment"))
+            .communicateChannels(List.of("phone", "sms"))
+            .onlineActivities(List.of("government"))
+            .financialChannels(List.of("mobile_banking"))
+            .familyType(FamilyType.WITH_CHILDREN)
             .build();
     }
 

--- a/apps/frontend/src/features/game-session/__tests__/LobbyPage.test.tsx
+++ b/apps/frontend/src/features/game-session/__tests__/LobbyPage.test.tsx
@@ -6,6 +6,7 @@ import { createWrapper } from '@/test/test-utils'
 
 import { gameApi } from '@/features/game/api'
 import { userApi } from '@/features/user/api'
+import { useAuthStore } from '@/features/auth/store'
 import { useGameStore } from '@/features/game/store'
 import { LobbyPage } from '../pages/LobbyPage'
 import type { GameSessionResponse, ScenarioSummary } from '@/features/game/types'
@@ -35,6 +36,9 @@ const mockedCreate = gameApi.createGameSession as unknown as Mock
 const mockedActive = gameApi.fetchActiveSession as unknown as Mock
 const mockedFetchDetail = gameApi.fetchScenarioDetail as unknown as Mock
 const mockedGetMe = userApi.getMe as unknown as Mock
+
+const findFirstRecommendedStartButton = async () =>
+  (await screen.findAllByRole('button', { name: /바로 시작하기/ }))[0]
 
 const baseProfile: UserProfile = {
   name: '테스터',
@@ -87,6 +91,12 @@ describe('LobbyPage', () => {
       root_node_id: 'n0',
       nodes: {},
     })
+    useAuthStore.setState({
+      accessToken: 'fake-access-token',
+      refreshToken: 'fake-refresh-token',
+      role: 'USER',
+      isAuthenticated: true,
+    })
     useGameStore.getState().reset()
   })
 
@@ -99,7 +109,7 @@ describe('LobbyPage', () => {
     expect(screen.getByText(/시나리오를 불러오고 있어요/)).toBeInTheDocument()
   })
 
-  it('renders fetched scenarios and the featured recommendation', async () => {
+  it('renders fetched scenarios and two featured recommendations', async () => {
     mockedFetch.mockResolvedValueOnce(baseScenarios)
 
     const { Wrapper } = createWrapper({ routerInitialEntries: ['/lobby'] })
@@ -108,8 +118,50 @@ describe('LobbyPage', () => {
     await waitFor(() => {
       expect(screen.getAllByText('택배 스미싱').length).toBeGreaterThan(0)
     })
-    expect(screen.getByText('보안 인증 알림')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /바로 시작하기/ })).toBeInTheDocument()
+    expect(screen.getAllByText('보안 인증 알림').length).toBeGreaterThan(0)
+    expect(screen.getAllByRole('button', { name: /바로 시작하기/ })).toHaveLength(2)
+    expect(screen.getByText('추천 1')).toBeInTheDocument()
+    expect(screen.getByText('추천 2')).toBeInTheDocument()
+  })
+
+  it('shows the top two survey-based recommendations before the original first scenario', async () => {
+    mockedGetMe.mockResolvedValueOnce({
+      ...baseProfile,
+      economicActivities: ['INVESTMENT'],
+      communicateChannels: ['PHONE'],
+      onlineActivities: ['GOVERNMENT'],
+      financialChannels: ['MOBILE_BANKING'],
+      familyType: 'WITH_CHILDREN',
+    } satisfies UserProfile)
+    mockedFetch.mockResolvedValueOnce([
+      {
+        ...baseScenarios[0],
+        tags: ['gender:female'],
+      },
+      {
+        ...baseScenarios[1],
+        tags: ['communicate:phone', 'financial:mobile_banking'],
+      },
+      {
+        ...baseScenarios[0],
+        scenario_id: 's3',
+        title: '정부기관 사칭',
+        tags: ['online:government', 'economic:investment'],
+      },
+    ])
+
+    const { Wrapper } = createWrapper({ routerInitialEntries: ['/lobby'] })
+    render(<LobbyPage />, { wrapper: Wrapper })
+
+    await waitFor(() => {
+      expect(screen.getByText('추천 1')).toBeInTheDocument()
+    })
+
+    const recommendedSection = screen.getByText('맞춤 추천').closest('section')
+    expect(recommendedSection).not.toBeNull()
+    expect(recommendedSection!.textContent).toContain('보안 인증 알림')
+    expect(recommendedSection!.textContent).toContain('정부기관 사칭')
+    expect(recommendedSection!.textContent).not.toContain('택배 스미싱')
   })
 
   it('shows empty state when scenario list is empty', async () => {
@@ -171,7 +223,10 @@ describe('LobbyPage', () => {
     const user = userEvent.setup()
     const startButtons = await screen.findAllByRole('button', { name: /시작하기/ })
     // Click the s2 card's start button by finding within s2 article
-    const s2Article = screen.getByText('보안 인증 알림').closest('article')
+    const s2Title = screen
+      .getAllByText('보안 인증 알림')
+      .find((element) => element.tagName.toLowerCase() === 'h3')
+    const s2Article = s2Title?.closest('article')
     expect(s2Article).not.toBeNull()
     const button = s2Article!.querySelector('button')!
     expect(button.textContent).toMatch(/시작하기/)
@@ -199,7 +254,7 @@ describe('LobbyPage', () => {
     render(<LobbyPage />, { wrapper: Wrapper })
 
     const user = userEvent.setup()
-    const startButton = await screen.findByRole('button', { name: /바로 시작하기/ })
+    const startButton = await findFirstRecommendedStartButton()
     await user.click(startButton)
 
     await waitFor(() => {
@@ -243,7 +298,7 @@ describe('LobbyPage', () => {
     render(<LobbyPage />, { wrapper: Wrapper })
 
     const user = userEvent.setup()
-    const startButton = await screen.findByRole('button', { name: /바로 시작하기/ })
+    const startButton = await findFirstRecommendedStartButton()
     await user.click(startButton)
 
     // 다이얼로그가 등장 — "이어하기" 버튼이 존재
@@ -302,7 +357,7 @@ describe('LobbyPage', () => {
     render(<LobbyPage />, { wrapper: Wrapper })
 
     const user = userEvent.setup()
-    const startButton = await screen.findByRole('button', { name: /바로 시작하기/ })
+    const startButton = await findFirstRecommendedStartButton()
     await user.click(startButton)
 
     const restartButton = await screen.findByRole('button', { name: '처음부터' })
@@ -348,7 +403,7 @@ describe('LobbyPage', () => {
     render(<LobbyPage />, { wrapper: Wrapper })
 
     const user = userEvent.setup()
-    const startButton = await screen.findByRole('button', { name: /바로 시작하기/ })
+    const startButton = await findFirstRecommendedStartButton()
     await user.click(startButton)
 
     await screen.findByRole('button', { name: '이어하기' })

--- a/apps/frontend/src/features/game-session/pages/LobbyPage.tsx
+++ b/apps/frontend/src/features/game-session/pages/LobbyPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
 import { toGameEngineError } from '@/features/game/api'
@@ -8,6 +8,7 @@ import {
   useFetchActiveSession,
   useScenarios,
 } from '@/features/game/hooks'
+import { getRecommendedScenarios } from '@/features/game/recommendation'
 import { useGameStore } from '@/features/game/store'
 import type { Difficulty, ScenarioSummary } from '@/features/game/types'
 import { useUserProfile } from '@/features/user/hooks'
@@ -209,7 +210,10 @@ export function LobbyPage() {
   const isStartingSession =
     fetchActiveMutation.isPending || createSessionMutation.isPending
 
-  const featuredScenario = scenariosQuery.data?.[0] ?? null
+  const recommendedScenarios = useMemo(
+    () => getRecommendedScenarios(profileQuery.data, scenariosQuery.data, 2),
+    [profileQuery.data, scenariosQuery.data],
+  )
 
   return (
     <section className="space-y-8 py-6">
@@ -302,22 +306,32 @@ export function LobbyPage() {
         </section>
       ) : null}
 
-      {featuredScenario ? (
+      {recommendedScenarios.length > 0 ? (
         <section className="rounded-lg border border-emerald-300/30 bg-emerald-300/10 p-5">
           <p className="text-sm font-semibold text-emerald-200">맞춤 추천</p>
-          <div className="mt-3 flex flex-col justify-between gap-4 md:flex-row md:items-center">
-            <div>
-              <h2 className="text-xl font-semibold text-white">{featuredScenario.title}</h2>
-              <p className="mt-2 text-slate-300">{featuredScenario.description}</p>
-            </div>
-            <button
-              type="button"
-              disabled={isStartingSession}
-              onClick={() => handleStart(featuredScenario.scenario_id)}
-              className="rounded-md bg-emerald-400 px-4 py-3 font-semibold text-slate-950 transition hover:bg-emerald-300 disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-400"
-            >
-              {isStartingSession ? '세션 생성 중...' : '바로 시작하기'}
-            </button>
+          <div className="mt-3 grid gap-4 md:grid-cols-2">
+            {recommendedScenarios.map((scenario, index) => (
+              <article
+                key={scenario.scenario_id}
+                className="flex h-full flex-col rounded-lg border border-emerald-200/20 bg-slate-950/35 p-4"
+              >
+                <p className="text-xs font-semibold text-emerald-200">
+                  추천 {index + 1}
+                </p>
+                <h2 className="mt-2 text-xl font-semibold text-white">{scenario.title}</h2>
+                <p className="mt-2 line-clamp-3 text-sm leading-6 text-slate-300">
+                  {scenario.description}
+                </p>
+                <button
+                  type="button"
+                  disabled={isStartingSession}
+                  onClick={() => handleStart(scenario.scenario_id)}
+                  className="mt-auto rounded-md bg-emerald-400 px-4 py-3 font-semibold text-slate-950 transition hover:bg-emerald-300 disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-400"
+                >
+                  {isStartingSession ? '세션 생성 중...' : '바로 시작하기'}
+                </button>
+              </article>
+            ))}
           </div>
         </section>
       ) : null}

--- a/apps/frontend/src/features/game/__tests__/recommendation.test.ts
+++ b/apps/frontend/src/features/game/__tests__/recommendation.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ScenarioSummary } from '@/features/game/types'
+import type { UserProfile } from '@/features/user/types'
+
+import {
+  buildUserSurveyTags,
+  getRecommendedScenarios,
+  scoreScenario,
+} from '../recommendation'
+
+const profile: UserProfile = {
+  name: '테스터',
+  email: 'tester@example.com',
+  occupation: 'SELF_EMPLOYED',
+  gender: 'MALE',
+  ageGroup: 'FORTIES',
+  economicActivities: ['INVESTMENT', 'NONE'],
+  communicateChannels: ['PHONE', 'SMS'],
+  onlineActivities: ['GOVERNMENT'],
+  financialChannels: ['MOBILE_BANKING'],
+  familyType: 'WITH_CHILDREN',
+}
+
+const makeScenario = (
+  scenarioId: string,
+  title: string,
+  tags: string[],
+): ScenarioSummary => ({
+  scenario_id: scenarioId,
+  title,
+  description: `${title} 설명`,
+  phishing_type: 'test',
+  difficulty: 'medium',
+  total_endings: 3,
+  total_good_endings: 1,
+  total_bad_endings: 2,
+  tags,
+})
+
+describe('scenario recommendation', () => {
+  it('builds survey tags from user onboarding fields and excludes NONE', () => {
+    const tags = buildUserSurveyTags(profile)
+
+    expect(tags).toContain('occupation:self_employed')
+    expect(tags).toContain('age_group:forties')
+    expect(tags).toContain('gender:male')
+    expect(tags).toContain('economic:investment')
+    expect(tags).toContain('communicate:phone')
+    expect(tags).toContain('communicate:sms')
+    expect(tags).toContain('online:government')
+    expect(tags).toContain('financial:mobile_banking')
+    expect(tags).toContain('family:with_children')
+    expect(tags).not.toContain('economic:none')
+  })
+
+  it('scores matched scenario tags with weighted prefixes', () => {
+    const tags = buildUserSurveyTags(profile)
+
+    expect(
+      scoreScenario(tags, [
+        'financial:mobile_banking',
+        'communicate:phone',
+        'online:government',
+        'gender:male',
+      ]),
+    ).toBe(12)
+  })
+
+  it('returns the top two scenarios by score while preserving order for ties', () => {
+    const scenarios = [
+      makeScenario('s1', '기본 시나리오', ['gender:male', 'age_group:forties']),
+      makeScenario('s2', '정부기관 사칭', [
+        'online:government',
+        'financial:mobile_banking',
+      ]),
+      makeScenario('s3', '전화 투자사기', [
+        'communicate:phone',
+        'economic:investment',
+      ]),
+    ]
+
+    const recommended = getRecommendedScenarios(profile, scenarios, 2)
+
+    expect(recommended.map((scenario) => scenario.scenario_id)).toEqual(['s2', 's3'])
+  })
+
+  it('falls back to the first two scenarios when profile details or tags are missing', () => {
+    const scenarios = [
+      makeScenario('s1', '첫 번째', []),
+      makeScenario('s2', '두 번째', []),
+      makeScenario('s3', '세 번째', []),
+    ]
+
+    expect(getRecommendedScenarios(undefined, scenarios, 2)).toEqual(
+      scenarios.slice(0, 2),
+    )
+    expect(getRecommendedScenarios(profile, scenarios, 2)).toEqual(
+      scenarios.slice(0, 2),
+    )
+  })
+})

--- a/apps/frontend/src/features/game/recommendation.ts
+++ b/apps/frontend/src/features/game/recommendation.ts
@@ -1,0 +1,106 @@
+import type { ScenarioSummary } from '@/features/game/types'
+import type { UserProfile } from '@/features/user/types'
+
+type TagPrefix =
+  | 'occupation'
+  | 'age_group'
+  | 'gender'
+  | 'economic'
+  | 'communicate'
+  | 'online'
+  | 'financial'
+  | 'family'
+
+const tagWeights: Record<TagPrefix, number> = {
+  financial: 4,
+  communicate: 4,
+  online: 3,
+  economic: 3,
+  occupation: 2,
+  family: 2,
+  age_group: 1,
+  gender: 1,
+}
+
+const toTagValue = (value: string) => value.toLowerCase()
+
+const addSingleTag = (
+  tags: Set<string>,
+  prefix: TagPrefix,
+  value: string | null | undefined,
+) => {
+  if (!value || value === 'NONE') return
+  tags.add(`${prefix}:${toTagValue(value)}`)
+}
+
+const addArrayTags = (
+  tags: Set<string>,
+  prefix: TagPrefix,
+  values: string[] | undefined,
+) => {
+  values?.forEach((value) => addSingleTag(tags, prefix, value))
+}
+
+const getTagPrefix = (tag: string): TagPrefix | null => {
+  const [prefix] = tag.split(':', 1)
+  return prefix in tagWeights ? (prefix as TagPrefix) : null
+}
+
+export const buildUserSurveyTags = (profile: UserProfile | null | undefined) => {
+  const tags = new Set<string>()
+  if (!profile) return tags
+
+  addSingleTag(tags, 'occupation', profile.occupation)
+  addSingleTag(tags, 'age_group', profile.ageGroup)
+  addSingleTag(tags, 'gender', profile.gender)
+  addArrayTags(tags, 'economic', profile.economicActivities)
+  addArrayTags(tags, 'communicate', profile.communicateChannels)
+  addArrayTags(tags, 'online', profile.onlineActivities)
+  addArrayTags(tags, 'financial', profile.financialChannels)
+  addSingleTag(tags, 'family', profile.familyType)
+
+  return tags
+}
+
+export const scoreScenario = (
+  userTags: Set<string>,
+  scenarioTags: string[] | undefined,
+) => {
+  const uniqueScenarioTags = new Set(scenarioTags ?? [])
+
+  return Array.from(uniqueScenarioTags).reduce((score, tag) => {
+    if (!userTags.has(tag)) return score
+
+    const prefix = getTagPrefix(tag)
+    if (!prefix) return score
+
+    return score + tagWeights[prefix]
+  }, 0)
+}
+
+export const getRecommendedScenarios = (
+  profile: UserProfile | null | undefined,
+  scenarios: ScenarioSummary[] | undefined,
+  limit = 2,
+) => {
+  if (!scenarios || scenarios.length === 0) return []
+
+  const fallback = scenarios.slice(0, limit)
+  const userTags = buildUserSurveyTags(profile)
+  if (userTags.size === 0) return fallback
+
+  const scoredScenarios = scenarios.map((scenario, index) => ({
+    scenario,
+    index,
+    score: scoreScenario(userTags, scenario.tags),
+  }))
+
+  if (scoredScenarios.every(({ score }) => score === 0)) {
+    return fallback
+  }
+
+  return [...scoredScenarios]
+    .sort((a, b) => b.score - a.score || a.index - b.index)
+    .slice(0, limit)
+    .map(({ scenario }) => scenario)
+}

--- a/apps/frontend/src/features/user/types.ts
+++ b/apps/frontend/src/features/user/types.ts
@@ -37,6 +37,7 @@ export type CommunicateChannel =
   | 'SNS'
   | 'EMAIL'
   | 'COMMUNITY'
+  | 'NONE'
 
 export type OnlineActivity =
   | 'USED_TRADE'
@@ -97,6 +98,11 @@ export type UserProfile = {
   occupation: Occupation | null
   gender: Gender | null
   ageGroup: AgeGroup | null
+  economicActivities?: EconomicActivity[]
+  communicateChannels?: CommunicateChannel[]
+  onlineActivities?: OnlineActivity[]
+  financialChannels?: FinancialChannel[]
+  familyType?: FamilyType | null
 }
 
 export type UpdateProfileRequest = {

--- a/apps/frontend/src/test/setup.ts
+++ b/apps/frontend/src/test/setup.ts
@@ -2,6 +2,46 @@ import '@testing-library/jest-dom/vitest'
 import { afterEach } from 'vitest'
 import { cleanup } from '@testing-library/react'
 
+const createStorageMock = (): Storage => {
+  let store: Record<string, string> = {}
+
+  return {
+    get length() {
+      return Object.keys(store).length
+    },
+    clear: () => {
+      store = {}
+    },
+    getItem: (key: string) => store[key] ?? null,
+    key: (index: number) => Object.keys(store)[index] ?? null,
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+  }
+}
+
+const ensureStorage = (name: 'localStorage' | 'sessionStorage') => {
+  const storage = globalThis[name]
+  if (
+    storage &&
+    typeof storage.clear === 'function' &&
+    typeof storage.getItem === 'function'
+  ) {
+    return
+  }
+
+  Object.defineProperty(globalThis, name, {
+    configurable: true,
+    value: createStorageMock(),
+  })
+}
+
+ensureStorage('localStorage')
+ensureStorage('sessionStorage')
+
 afterEach(() => {
   cleanup()
   sessionStorage.clear()

--- a/apps/game-engine/app/scripts/seed.py
+++ b/apps/game-engine/app/scripts/seed.py
@@ -13,7 +13,7 @@
     2. 각 시나리오를 scenarios 컬렉션에 upsert (idempotent)
        - metadata 필드 제외
        - nodes 순회하여 total_endings / total_good_endings / total_bad_endings 파생
-       - tags=[], updated_at=now
+       - JSON tags 보존, updated_at=now
     3. 예시 데이터 시드 (user_id=1):
        - 완료된 플레이 2건: good ending 1, bad ending 1
        - 진행 중 세션 1건
@@ -55,18 +55,23 @@ def _load_scenario_json(file_path: Path) -> dict[str, Any]:
         return json.load(f)
 
 
+def _scenario_id(raw: dict[str, Any]) -> str:
+    """신/구 시나리오 JSON 키를 모두 지원."""
+    return raw.get("scenario_id") or raw["id"]
+
+
 def _to_scenario_doc(raw: dict[str, Any]) -> Scenario:
     """JSON dict → Scenario Document.
 
-    - `id` → `scenario_id` rename
+    - `id` 또는 `scenario_id` → `scenario_id`
     - `metadata` 제외
     - 파생 필드 계산
-    - `tags=[]`, `updated_at=now`
+    - JSON tags 보존, `updated_at=now`
     """
     total, good, bad = _derive_ending_counts(raw["nodes"])
     now = datetime.now(UTC)
     return Scenario(
-        scenario_id=raw["id"],
+        scenario_id=_scenario_id(raw),
         title=raw["title"],
         description=raw["description"],
         phishing_type=raw["phishing_type"],
@@ -78,7 +83,7 @@ def _to_scenario_doc(raw: dict[str, Any]) -> Scenario:
         total_endings=total,
         total_good_endings=good,
         total_bad_endings=bad,
-        tags=[],
+        tags=raw.get("tags", []),
         created_at=raw["created_at"],
         updated_at=now,
     )
@@ -206,7 +211,7 @@ async def _seed_example_data(scenarios_dir: Path) -> None:
         "log_id",
         PlayLog(
             log_id="example_log_1",
-            scenario_id=sc_a["id"],
+            scenario_id=_scenario_id(sc_a),
             user_id=EXAMPLE_USER_ID,
             path=path_a,
             final_node_id=final_a,
@@ -225,7 +230,7 @@ async def _seed_example_data(scenarios_dir: Path) -> None:
         "session_id",
         GameSession(
             session_id="example_session_completed_1",
-            scenario_id=sc_a["id"],
+            scenario_id=_scenario_id(sc_a),
             user_id=EXAMPLE_USER_ID,
             current_node_id=final_a,
             resources=Resources(trust=2, money=4, awareness=4),
@@ -249,7 +254,7 @@ async def _seed_example_data(scenarios_dir: Path) -> None:
         "log_id",
         PlayLog(
             log_id="example_log_2",
-            scenario_id=sc_b["id"],
+            scenario_id=_scenario_id(sc_b),
             user_id=EXAMPLE_USER_ID,
             path=path_b,
             final_node_id=final_b,
@@ -268,7 +273,7 @@ async def _seed_example_data(scenarios_dir: Path) -> None:
         "session_id",
         GameSession(
             session_id="example_session_completed_2",
-            scenario_id=sc_b["id"],
+            scenario_id=_scenario_id(sc_b),
             user_id=EXAMPLE_USER_ID,
             current_node_id=final_b,
             resources=Resources(trust=4, money=0, awareness=1),
@@ -289,7 +294,7 @@ async def _seed_example_data(scenarios_dir: Path) -> None:
         "session_id",
         GameSession(
             session_id="example_session_playing_1",
-            scenario_id=sc_c["id"],
+            scenario_id=_scenario_id(sc_c),
             user_id=EXAMPLE_USER_ID,
             current_node_id=sc_c["root_node_id"],
             resources=Resources(),  # 기본값 (3/3/1)
@@ -327,11 +332,11 @@ async def _upsert_progress(
     total, _, _ = _derive_ending_counts(scenario_raw["nodes"])
     rate = len(discovered) / total if total > 0 else 0.0
     existing = await UserScenarioProgress.find_one(
-        {"user_id": EXAMPLE_USER_ID, "scenario_id": scenario_raw["id"]}
+        {"user_id": EXAMPLE_USER_ID, "scenario_id": _scenario_id(scenario_raw)}
     )
     doc = UserScenarioProgress(
         user_id=EXAMPLE_USER_ID,
-        scenario_id=scenario_raw["id"],
+        scenario_id=_scenario_id(scenario_raw),
         discovered_endings=discovered,
         total_endings=total,
         completion_rate=rate,


### PR DESCRIPTION
## 관련 이슈
Closes #61

## 작업 내용
온보딩 설문 응답과 시나리오 tags를 기반으로 로비의 맞춤 추천 시나리오를 선택하도록 구현했습니다.  



## 변경 사항
- `/users/me` 응답에 온보딩 상세 설문값 추가
- 프론트 `UserProfile` 타입 확장
- 설문값 기반 추천 태그 생성 및 시나리오 점수 계산 로직 추가
- 로비 맞춤 추천 영역을 추천 시나리오 2개 표시로 변경
- 최종 시나리오 JSON에 추천용 tags 추가
- game-engine seed가 JSON tags를 Mongo에 반영하도록 수정 

## 체크리스트
- [x] 코드 포맷팅(Checkstyle, Lint 등)을 적용하였는가?
- [x] 테스트 코드를 작성하고 통과했는가?
- [x] 불필요한 console.log / print 등을 제거했는가?
- [x] 로컬 테스트를 완료했는가?
- [x] 관련 서비스 동작을 확인했는가?

## 테스트


## 스크린샷
UI 변경이 있다면 첨부해주세요.

## 리뷰 포인트
- `/users/me` 응답에 추가된 상세 설문 필드 구조
- 추천 점수 가중치가 설문 항목 중요도에 맞는지
- 시나리오별 tags가 각 시나리오 성격에 적절한지
- seed 스크립트가 기존/신규 scenario id 키를 모두 안전하게 처리하는지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자 온보딩 설문 데이터 기반 맞춤형 시나리오 추천 시스템 추가
  * 로비 페이지에서 최대 2개의 추천 시나리오 표시
  * 모든 시나리오에 카테고리 태그 적용으로 분류 체계 강화

* **개선 사항**
  * 사용자 프로필이 없는 경우에도 안정적으로 정보 조회 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->