### PR TITLE
[FEAT] 시나리오별 플레이기록, 플레이기록별 상세 조회 API 구현 (#69)

### DIFF
--- a/apps/backend/src/main/java/com/sos/backend/domain/history/controller/HistoryController.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/history/controller/HistoryController.java
@@ -1,5 +1,6 @@
 package com.sos.backend.domain.history.controller;
 
+import com.sos.backend.domain.history.dto.response.PlayLogSummaryResponse;
 import com.sos.backend.domain.history.dto.response.ScenarioProgressResponse;
 import com.sos.backend.domain.history.service.HistoryService;
 import com.sos.backend.global.common.response.ApiResponse;
@@ -14,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -41,5 +43,25 @@ public class HistoryController {
         @AuthenticationPrincipal Long userId
     ) {
         return ApiResponse.success(historyService.getScenarioProgress(userId));
+    }
+
+    @Operation(summary = "시나리오별 플레이 기록 목록 조회",
+        description = "특정 시나리오에서 사용자가 완료한 플레이 기록 목록을 조회한다. Game Engine internal API 호출.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "플레이 기록 목록 조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401",
+            description = "Access Token 무효/만료/미첨부 (UNAUTHORIZED / INVALID_TOKEN / EXPIRED_TOKEN)",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "502",
+            description = "Game Engine 호출 실패 (INTERNAL_API_ERROR)",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class)))
+    })
+    @GetMapping("/play-logs")
+    @SecurityRequirement(name = "bearerAuth")
+    public ApiResponse<List<PlayLogSummaryResponse>> getPlayLogs(
+        @AuthenticationPrincipal Long userId,
+        @RequestParam String scenarioId
+    ) {
+        return ApiResponse.success(historyService.getPlayLogs(userId, scenarioId));
     }
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/history/controller/HistoryController.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/history/controller/HistoryController.java
@@ -1,5 +1,6 @@
 package com.sos.backend.domain.history.controller;
 
+import com.sos.backend.domain.history.dto.response.PlayLogDetailResponse;
 import com.sos.backend.domain.history.dto.response.PlayLogSummaryResponse;
 import com.sos.backend.domain.history.dto.response.ScenarioProgressResponse;
 import com.sos.backend.domain.history.service.HistoryService;
@@ -13,10 +14,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/users/me/history")
@@ -63,5 +61,28 @@ public class HistoryController {
         @RequestParam String scenarioId
     ) {
         return ApiResponse.success(historyService.getPlayLogs(userId, scenarioId));
+    }
+
+    @Operation(summary = "플레이 기록 상세(결말) 조회",
+        description = "플레이 기록의 결말 상세(사진 + 결말 요약 텍스트 + 카테고리)를 조회한다. Game Engine internal API 호출.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "플레이 기록 상세 조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401",
+            description = "Access Token 무효/만료/미첨부 (UNAUTHORIZED / INVALID_TOKEN / EXPIRED_TOKEN)",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404",
+            description = "플레이 기록 없음 또는 타인 소유 (PLAY_LOG_NOT_FOUND)",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "502",
+            description = "Game Engine 호출 실패 (INTERNAL_API_ERROR)",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class)))
+    })
+    @GetMapping("/play-logs/{logId}")
+    @SecurityRequirement(name = "bearerAuth")
+    public ApiResponse<PlayLogDetailResponse> getPlayLogDetail(
+        @AuthenticationPrincipal Long userId,
+        @PathVariable String logId
+    ) {
+        return ApiResponse.success(historyService.getPlayLogDetail(logId, userId));
     }
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/history/dto/response/PlayLogDetailResponse.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/history/dto/response/PlayLogDetailResponse.java
@@ -1,0 +1,30 @@
+package com.sos.backend.domain.history.dto.response;
+
+import com.sos.backend.global.internal.dto.PlayLogDetailInternalResponse;
+
+public record PlayLogDetailResponse(
+    String logId,
+    String scenarioId,
+    String imageUrl,
+    String text,
+    EndingCategory endingCategory
+) {
+    public record EndingCategory(String label, String description) {
+    }
+
+    public static PlayLogDetailResponse from(PlayLogDetailInternalResponse internal) {
+        EndingCategory category = internal.endingCategory() == null
+            ? null
+            : new EndingCategory(
+            internal.endingCategory().label(),
+            internal.endingCategory().description()
+        );
+        return new PlayLogDetailResponse(
+            internal.logId(),
+            internal.scenarioId(),
+            internal.imageUrl(),
+            internal.text(),
+            category
+        );
+    }
+}

--- a/apps/backend/src/main/java/com/sos/backend/domain/history/dto/response/PlayLogSummaryResponse.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/history/dto/response/PlayLogSummaryResponse.java
@@ -1,0 +1,25 @@
+package com.sos.backend.domain.history.dto.response;
+
+import com.sos.backend.global.internal.dto.PlayLogSummaryInternalResponse;
+
+import java.time.LocalDateTime;
+
+public record PlayLogSummaryResponse(
+    String logId,
+    String endingType,
+    int totalScore,
+    int dangerousCount,
+    int durationSeconds,
+    LocalDateTime completedAt
+) {
+    public static PlayLogSummaryResponse from(PlayLogSummaryInternalResponse internal) {
+        return new PlayLogSummaryResponse(
+            internal.logId(),
+            internal.endingType(),
+            internal.totalScore(),
+            internal.dangerousCount(),
+            internal.durationSeconds(),
+            internal.completedAt()
+        );
+    }
+}

--- a/apps/backend/src/main/java/com/sos/backend/domain/history/service/HistoryService.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/history/service/HistoryService.java
@@ -1,5 +1,6 @@
 package com.sos.backend.domain.history.service;
 
+import com.sos.backend.domain.history.dto.response.PlayLogSummaryResponse;
 import com.sos.backend.domain.history.dto.response.ScenarioProgressResponse;
 import com.sos.backend.global.internal.GameEngineClient;
 import java.util.List;
@@ -15,6 +16,12 @@ public class HistoryService {
     public List<ScenarioProgressResponse> getScenarioProgress(Long userId) {
         return gameEngineClient.getUserProgress(userId).stream()
             .map(ScenarioProgressResponse::from)
+            .toList();
+    }
+
+    public List<PlayLogSummaryResponse> getPlayLogs(Long userId, String scenarioId) {
+        return gameEngineClient.getPlayLogs(userId, scenarioId).stream()
+            .map(PlayLogSummaryResponse::from)
             .toList();
     }
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/history/service/HistoryService.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/history/service/HistoryService.java
@@ -1,5 +1,6 @@
 package com.sos.backend.domain.history.service;
 
+import com.sos.backend.domain.history.dto.response.PlayLogDetailResponse;
 import com.sos.backend.domain.history.dto.response.PlayLogSummaryResponse;
 import com.sos.backend.domain.history.dto.response.ScenarioProgressResponse;
 import com.sos.backend.global.internal.GameEngineClient;
@@ -23,5 +24,11 @@ public class HistoryService {
         return gameEngineClient.getPlayLogs(userId, scenarioId).stream()
             .map(PlayLogSummaryResponse::from)
             .toList();
+    }
+
+    public PlayLogDetailResponse getPlayLogDetail(String logId, Long userId) {
+        return PlayLogDetailResponse.from(
+            gameEngineClient.getPlayLogDetail(logId, userId)
+        );
     }
 }

--- a/apps/backend/src/main/java/com/sos/backend/global/common/exception/ErrorCode.java
+++ b/apps/backend/src/main/java/com/sos/backend/global/common/exception/ErrorCode.java
@@ -33,6 +33,9 @@ public enum ErrorCode {
     // Notification
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "알림을 찾을 수 없습니다"),
 
+    // History
+    PLAY_LOG_NOT_FOUND(HttpStatus.NOT_FOUND, "플레이 기록을 찾을 수 없습니다"),
+
     // Internal (server-to-server)
     INVALID_INTERNAL_API_KEY(HttpStatus.UNAUTHORIZED, "유효하지 않은 내부 API 키입니다"),
     INTERNAL_API_ERROR(HttpStatus.BAD_GATEWAY, "외부 서비스 호출에 실패했습니다");

--- a/apps/backend/src/main/java/com/sos/backend/global/internal/GameEngineClient.java
+++ b/apps/backend/src/main/java/com/sos/backend/global/internal/GameEngineClient.java
@@ -64,10 +64,15 @@ public class GameEngineClient {
 
     public PlayLogDetailInternalResponse getPlayLogDetail(String logId, long userId) {
         try {
-            return restClient.get()
+            PlayLogDetailInternalResponse result = restClient.get()
                 .uri("/api/internal/play-logs/{logId}?user_id={userId}", logId, userId)
                 .retrieve()
                 .body(PlayLogDetailInternalResponse.class);
+            if (result == null) {
+                log.error("Game Engine internal play-log detail returned empty body: logId={}, userId={}", logId, userId);
+                throw new CustomException(ErrorCode.INTERNAL_API_ERROR);
+            }
+            return result;
         } catch (HttpClientErrorException.NotFound e) {
             // engine 404 (미존재/타인 소유) → 공개 404. 502 로 collapse 금지.
             throw new CustomException(ErrorCode.PLAY_LOG_NOT_FOUND);

--- a/apps/backend/src/main/java/com/sos/backend/global/internal/GameEngineClient.java
+++ b/apps/backend/src/main/java/com/sos/backend/global/internal/GameEngineClient.java
@@ -3,6 +3,7 @@ package com.sos.backend.global.internal;
 import com.sos.backend.global.common.exception.CustomException;
 import com.sos.backend.global.common.exception.ErrorCode;
 import com.sos.backend.global.internal.dto.ScenarioProgressInternalResponse;
+import com.sos.backend.global.internal.dto.PlayLogSummaryInternalResponse;
 import java.time.Duration;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -41,6 +42,20 @@ public class GameEngineClient {
             return result != null ? result : List.of();
         } catch (RestClientException e) {
             log.error("Game Engine internal progress call failed: userId={}", userId, e);
+            throw new CustomException(ErrorCode.INTERNAL_API_ERROR);
+        }
+    }
+
+    public List<PlayLogSummaryInternalResponse> getPlayLogs(long userId, String scenarioId) {
+        try {
+            List<PlayLogSummaryInternalResponse> result = restClient.get()
+                .uri("/api/internal/play-logs/user/{userId}?scenario_id={scenarioId}", userId, scenarioId)
+                .retrieve()
+                .body(new ParameterizedTypeReference<List<PlayLogSummaryInternalResponse>>() {});
+            return result != null ? result : List.of();
+        } catch (RestClientException e) {
+            log.error("Game Engine internal play-logs call failed: userId={}, scenarioId={}",
+                userId, scenarioId, e);
             throw new CustomException(ErrorCode.INTERNAL_API_ERROR);
         }
     }

--- a/apps/backend/src/main/java/com/sos/backend/global/internal/GameEngineClient.java
+++ b/apps/backend/src/main/java/com/sos/backend/global/internal/GameEngineClient.java
@@ -2,6 +2,7 @@ package com.sos.backend.global.internal;
 
 import com.sos.backend.global.common.exception.CustomException;
 import com.sos.backend.global.common.exception.ErrorCode;
+import com.sos.backend.global.internal.dto.PlayLogDetailInternalResponse;
 import com.sos.backend.global.internal.dto.ScenarioProgressInternalResponse;
 import com.sos.backend.global.internal.dto.PlayLogSummaryInternalResponse;
 import java.time.Duration;
@@ -11,6 +12,7 @@ import org.springframework.boot.http.client.ClientHttpRequestFactoryBuilder;
 import org.springframework.boot.http.client.ClientHttpRequestFactorySettings;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 
@@ -56,6 +58,23 @@ public class GameEngineClient {
         } catch (RestClientException e) {
             log.error("Game Engine internal play-logs call failed: userId={}, scenarioId={}",
                 userId, scenarioId, e);
+            throw new CustomException(ErrorCode.INTERNAL_API_ERROR);
+        }
+    }
+
+    public PlayLogDetailInternalResponse getPlayLogDetail(String logId, long userId) {
+        try {
+            return restClient.get()
+                .uri("/api/internal/play-logs/{logId}?user_id={userId}", logId, userId)
+                .retrieve()
+                .body(PlayLogDetailInternalResponse.class);
+        } catch (HttpClientErrorException.NotFound e) {
+            // engine 404 (미존재/타인 소유) → 공개 404. 502 로 collapse 금지.
+            throw new CustomException(ErrorCode.PLAY_LOG_NOT_FOUND);
+        } catch (RestClientException e) {
+            // engine down / 401 / 403 / 5xx / timeout → 502.
+            log.error("Game Engine internal play-log detail call failed: logId={}, userId={}",
+                logId, userId, e);
             throw new CustomException(ErrorCode.INTERNAL_API_ERROR);
         }
     }

--- a/apps/backend/src/main/java/com/sos/backend/global/internal/dto/PlayLogDetailInternalResponse.java
+++ b/apps/backend/src/main/java/com/sos/backend/global/internal/dto/PlayLogDetailInternalResponse.java
@@ -1,0 +1,16 @@
+package com.sos.backend.global.internal.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record PlayLogDetailInternalResponse(
+    String logId,
+    String scenarioId,
+    String imageUrl,
+    String text,
+    EndingCategory endingCategory
+) {
+    public record EndingCategory(String label, String description) {
+    }
+}

--- a/apps/backend/src/main/java/com/sos/backend/global/internal/dto/PlayLogSummaryInternalResponse.java
+++ b/apps/backend/src/main/java/com/sos/backend/global/internal/dto/PlayLogSummaryInternalResponse.java
@@ -1,0 +1,20 @@
+package com.sos.backend.global.internal.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.sos.backend.global.common.json.FlexibleUtcDateTimeDeserializer;
+
+import java.time.LocalDateTime;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record PlayLogSummaryInternalResponse(
+    String logId,
+    String endingType,
+    int totalScore,
+    int dangerousCount,
+    int durationSeconds,
+    @JsonDeserialize(using = FlexibleUtcDateTimeDeserializer.class)
+    LocalDateTime completedAt
+) {
+}

--- a/apps/backend/src/test/java/com/sos/backend/domain/history/service/HistoryServiceTest.java
+++ b/apps/backend/src/test/java/com/sos/backend/domain/history/service/HistoryServiceTest.java
@@ -1,13 +1,18 @@
 package com.sos.backend.domain.history.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
+import com.sos.backend.domain.history.dto.response.PlayLogDetailResponse;
 import com.sos.backend.domain.history.dto.response.PlayLogSummaryResponse;
 import com.sos.backend.domain.history.dto.response.ScenarioProgressResponse;
+import com.sos.backend.global.common.exception.CustomException;
+import com.sos.backend.global.common.exception.ErrorCode;
 import com.sos.backend.global.internal.GameEngineClient;
+import com.sos.backend.global.internal.dto.PlayLogDetailInternalResponse;
 import com.sos.backend.global.internal.dto.PlayLogSummaryInternalResponse;
 import com.sos.backend.global.internal.dto.ScenarioProgressInternalResponse;
 
@@ -79,5 +84,59 @@ class HistoryServiceTest {
         given(gameEngineClient.getPlayLogs(anyLong(), anyString())).willReturn(List.of());
 
         assertThat(historyService.getPlayLogs(1001L, "scenario_x")).isEmpty();
+    }
+
+    @Test
+    void getPlayLogDetail_mapsInternalToPublic() {
+        String logId = "log_x9y8z7w6v5";
+        long userId = 1001L;
+        given(gameEngineClient.getPlayLogDetail(logId, userId)).willReturn(
+            new PlayLogDetailInternalResponse(
+                logId, "scenario_5d6e8982",
+                "https://img/ending.png", "결말 서술 텍스트",
+                new PlayLogDetailInternalResponse.EndingCategory("피해 발생", "자산을 잃었습니다")
+            )
+        );
+
+        PlayLogDetailResponse result = historyService.getPlayLogDetail(logId, userId);
+
+        assertThat(result.logId()).isEqualTo(logId);
+        assertThat(result.scenarioId()).isEqualTo("scenario_5d6e8982");
+        assertThat(result.imageUrl()).isEqualTo("https://img/ending.png");
+        assertThat(result.text()).isEqualTo("결말 서술 텍스트");
+        assertThat(result.endingCategory().label()).isEqualTo("피해 발생");
+        assertThat(result.endingCategory().description()).isEqualTo("자산을 잃었습니다");
+    }
+
+    @Test
+    void getPlayLogDetail_mapsNullCategory() {
+        given(gameEngineClient.getPlayLogDetail("log_1", 1001L)).willReturn(
+            new PlayLogDetailInternalResponse(
+                "log_1", "scenario_1", "https://img/x.png", "텍스트", null
+            )
+        );
+
+        PlayLogDetailResponse result = historyService.getPlayLogDetail("log_1", 1001L);
+
+        assertThat(result.endingCategory()).isNull();
+        assertThat(result.imageUrl()).isEqualTo("https://img/x.png");
+    }
+
+    @Test
+    void getPlayLogDetail_propagatesNotFound() {
+        CustomException notFound = new CustomException(ErrorCode.PLAY_LOG_NOT_FOUND);
+        given(gameEngineClient.getPlayLogDetail("nope", 1001L)).willThrow(notFound);
+
+        assertThatThrownBy(() -> historyService.getPlayLogDetail("nope", 1001L))
+            .isSameAs(notFound);
+    }
+
+    @Test
+    void getPlayLogDetail_propagatesInternalApiError() {
+        CustomException error = new CustomException(ErrorCode.INTERNAL_API_ERROR);
+        given(gameEngineClient.getPlayLogDetail("log_1", 1001L)).willThrow(error);
+
+        assertThatThrownBy(() -> historyService.getPlayLogDetail("log_1", 1001L))
+            .isSameAs(error);
     }
 }

--- a/apps/backend/src/test/java/com/sos/backend/domain/history/service/HistoryServiceTest.java
+++ b/apps/backend/src/test/java/com/sos/backend/domain/history/service/HistoryServiceTest.java
@@ -2,10 +2,13 @@ package com.sos.backend.domain.history.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
+import com.sos.backend.domain.history.dto.response.PlayLogSummaryResponse;
 import com.sos.backend.domain.history.dto.response.ScenarioProgressResponse;
 import com.sos.backend.global.internal.GameEngineClient;
+import com.sos.backend.global.internal.dto.PlayLogSummaryInternalResponse;
 import com.sos.backend.global.internal.dto.ScenarioProgressInternalResponse;
 
 import java.time.LocalDateTime;
@@ -47,5 +50,34 @@ class HistoryServiceTest {
         given(gameEngineClient.getUserProgress(anyLong())).willReturn(List.of());
 
         assertThat(historyService.getScenarioProgress(1001L)).isEmpty();
+    }
+
+    @Test
+    void getPlayLogs_mapsInternalToPublic() {
+        long userId = 1001L;
+        String scenarioId = "scenario_5d6e8982";
+        given(gameEngineClient.getPlayLogs(userId, scenarioId)).willReturn(List.of(
+            new PlayLogSummaryInternalResponse(
+                "log_x9y8z7w6v5", "ending_bad", 22, 4, 487,
+                LocalDateTime.of(2026, 4, 1, 10, 8, 7)
+            )
+        ));
+
+        List<PlayLogSummaryResponse> result = historyService.getPlayLogs(userId, scenarioId);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).logId()).isEqualTo("log_x9y8z7w6v5");
+        assertThat(result.get(0).endingType()).isEqualTo("ending_bad");
+        assertThat(result.get(0).totalScore()).isEqualTo(22);
+        assertThat(result.get(0).dangerousCount()).isEqualTo(4);
+        assertThat(result.get(0).durationSeconds()).isEqualTo(487);
+        assertThat(result.get(0).completedAt()).isEqualTo(LocalDateTime.of(2026, 4, 1, 10, 8, 7));
+    }
+
+    @Test
+    void getPlayLogs_returnsEmptyWhenNone() {
+        given(gameEngineClient.getPlayLogs(anyLong(), anyString())).willReturn(List.of());
+
+        assertThat(historyService.getPlayLogs(1001L, "scenario_x")).isEmpty();
     }
 }

--- a/apps/game-engine/app/api/routes/internal.py
+++ b/apps/game-engine/app/api/routes/internal.py
@@ -5,11 +5,18 @@ get_current_user 미사용 — 호출자는 backend 서비스, 사용자 신원�
 """
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 
 from app.core.internal_auth import verify_internal_api_key
+from app.models.play_log import PlayLog
+from app.models.scenario import Scenario
 from app.models.user_scenario_progress import UserScenarioProgress
-from app.schemas.game import ScenarioProgressResponse
+from app.schemas.game import (
+    EndingCategoryView,
+    PlayLogDetailResponse,
+    PlayLogSummaryResponse,
+    ScenarioProgressResponse,
+)
 
 router = APIRouter(
     tags=["internal"],
@@ -40,3 +47,71 @@ async def list_user_progress(user_id: int) -> list[ScenarioProgressResponse]:
         )
         for r in rows
     ]
+
+
+@router.get(
+    "/play-logs/user/{user_id}",
+    response_model=list[PlayLogSummaryResponse],
+    summary="유저 시나리오별 플레이 기록 목록 (internal)",
+)
+async def list_user_play_logs(
+    user_id: int,
+    scenario_id: str,
+) -> list[PlayLogSummaryResponse]:
+    # 완료(ending 도달) 기록만 play_logs 에 존재. (user_id, scenario_id) 복합인덱스 조회.
+    rows = (
+        await PlayLog.find(
+            PlayLog.user_id == user_id,
+            PlayLog.scenario_id == scenario_id,
+        )
+        .sort("-completed_at")
+        .to_list()
+    )
+    return [
+        PlayLogSummaryResponse(
+            log_id=r.log_id,
+            ending_type=r.ending_type,
+            total_score=r.total_score,
+            dangerous_count=r.dangerous_count,
+            duration_seconds=r.duration_seconds,
+            completed_at=r.completed_at,
+        )
+        for r in rows
+    ]
+
+
+@router.get(
+    "/play-logs/{log_id}",
+    response_model=PlayLogDetailResponse,
+    summary="플레이 기록 상세 — 결말 (internal)",
+)
+async def get_play_log_detail(
+    log_id: str,
+    user_id: int,
+) -> PlayLogDetailResponse:
+    # business key 조회는 find_one (Model.get() 은 _id 조회라 항상 None).
+    log = await PlayLog.find_one(PlayLog.log_id == log_id)
+    # 존재 안 함 / 타인 소유 모두 404 (존재 비노출, 403 아님).
+    if log is None or log.user_id != user_id:
+        raise HTTPException(status_code=404, detail="Play log not found")
+
+    scenario = await Scenario.find_one(Scenario.scenario_id == log.scenario_id)
+    node = scenario.nodes.get(log.final_node_id) if scenario else None
+    # 시나리오/노드 부재(하드삭제·in-place 재발행) → 결말 콘텐츠 없음 → 404.
+    if scenario is None or node is None:
+        raise HTTPException(status_code=404, detail="Ending content not found")
+
+    # 카테고리: ending_categories·node.ending_category 둘 다 존재 + dangling 아닐 때만.
+    category: EndingCategoryView | None = None
+    if scenario.ending_categories and node.ending_category:
+        cat = scenario.ending_categories.get(node.ending_category)
+        if cat is not None:
+            category = EndingCategoryView(label=cat.label, description=cat.description)
+
+    return PlayLogDetailResponse(
+        log_id=log.log_id,
+        scenario_id=log.scenario_id,
+        image_url=node.image_url,
+        text=node.text,
+        ending_category=category,
+    )

--- a/apps/game-engine/app/schemas/game.py
+++ b/apps/game-engine/app/schemas/game.py
@@ -116,3 +116,36 @@ class ScenarioProgressResponse(BaseModel):
     discovered_count: int
     total_endings: int
     last_played_at: datetime
+
+class PlayLogSummaryResponse(BaseModel):
+    """internal: GET /api/internal/play-logs/user/{user_id}?scenario_id={id} 응답
+    
+    전부 play_log denorm — 시나리오 join 불필요. completed_at desc 정렬은 라우트 책임.
+    """
+
+    log_id: str
+    ending_type: Literal["ending_good", "ending_bad"]
+    total_score: int
+    dangerous_count: int
+    duration_seconds: int
+    completed_at: datetime
+
+
+class EndingCategoryView(BaseModel):
+    """결말 카테고리 표시용. ending_classifier 미실행 시 None."""
+
+    label: str
+    description: str
+
+
+class PlayLogDetailResponse(BaseModel):
+    """internal: GET /api/internal/play-logs/{log_id}?user_id={userId} 응답
+
+    사진 + 결말 요약만. final_resource·플레이 스탯 제외 (play_log 에 denorm 돼 있어 추후 필요 시 무비용 추가). 식별자 + 결말 콘텐츠.
+    """
+
+    log_id: str
+    scenario_id: str
+    image_url: str | None = None
+    text: str
+    ending_category: EndingCategoryView | None = None

--- a/apps/game-engine/tests/test_internal_play_logs.py
+++ b/apps/game-engine/tests/test_internal_play_logs.py
@@ -1,0 +1,197 @@
+"""internal play-logs 엔드포인트 — 목록 / 결말 상세.
+
+auth(X-Internal-Api-Key)는 test_internal_auth.py 가 책임 → 여기선 verify_internal_api_key 를
+override 하고 로직(소유 404 / 빈목록 / 카테고리 None / 정렬)만 검증한다.
+internal 라우터는 conftest 의 app_for_routes 에 없어 전용 app·client fixture 를 둔다.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+
+from app.api.routes import internal as internal_routes
+from app.core.internal_auth import verify_internal_api_key
+from app.models.common import EndingCategory, Resources, ScenarioNode
+from app.models.play_log import PlayLog
+from app.models.scenario import Scenario
+
+
+@pytest.fixture
+def internal_app(test_db) -> FastAPI:
+    app = FastAPI()
+    app.include_router(internal_routes.router, prefix="/api/internal")
+    app.dependency_overrides[verify_internal_api_key] = lambda: None
+    return app
+
+
+@pytest_asyncio.fixture
+async def internal_client(internal_app: FastAPI):
+    transport = httpx.ASGITransport(app=internal_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    internal_app.dependency_overrides.clear()
+
+
+# ---- 시드 헬퍼 ----
+
+async def _seed_play_log(
+    *,
+    log_id: str,
+    user_id: int,
+    scenario_id: str,
+    completed_at: datetime,
+    final_node_id: str = "end_bad_1",
+    ending_type: str = "ending_bad",
+) -> None:
+    await PlayLog(
+        log_id=log_id,
+        scenario_id=scenario_id,
+        user_id=user_id,
+        path=[0],
+        final_node_id=final_node_id,
+        ending_type=ending_type,
+        final_resource=Resources(trust=1, money=2, awareness=3),
+        total_score=42,
+        dangerous_count=1,
+        total_choices=3,
+        phishing_type="smishing",
+        duration_seconds=120,
+        completed_at=completed_at,
+    ).insert()
+
+
+async def _seed_scenario(
+    *,
+    scenario_id: str,
+    final_node_id: str = "end_bad_1",
+    with_category: bool = True,
+) -> None:
+    node = ScenarioNode(
+        id=final_node_id,
+        type="ending_bad",
+        text="결말 서술 텍스트",
+        image_url="https://img/ending.png",
+        ending_category="cat_loss" if with_category else None,
+    )
+    cats = (
+        {
+            "cat_loss": EndingCategory(
+                category_id="cat_loss",
+                label="피해 발생",
+                description="자산을 잃었습니다",
+                node_ids=[final_node_id],
+            )
+        }
+        if with_category
+        else None
+    )
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    await Scenario(
+        scenario_id=scenario_id,
+        title="t",
+        description="d",
+        phishing_type="smishing",
+        difficulty="easy",
+        root_node_id="root",
+        nodes={final_node_id: node},
+        total_endings=1,
+        total_good_endings=0,
+        total_bad_endings=1,
+        ending_categories=cats,
+        created_at=now,
+        updated_at=now,
+    ).insert()
+
+
+# ---- 목록 ----
+
+async def test_empty_returns_200_empty_list(internal_client, test_db):
+    resp = await internal_client.get(
+        "/api/internal/play-logs/user/42", params={"scenario_id": "s_none"}
+    )
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+async def test_lists_own_scenario_plays_completed_desc(internal_client, test_db):
+    await _seed_play_log(log_id="log_old", user_id=42, scenario_id="s_1", completed_at=datetime(2026, 1, 1, tzinfo=timezone.utc))
+    await _seed_play_log(log_id="log_new", user_id=42, scenario_id="s_1", completed_at=datetime(2026, 3, 1, tzinfo=timezone.utc))
+    await _seed_play_log(log_id="log_other_user", user_id=99, scenario_id="s_1", completed_at=datetime(2026, 2, 1, tzinfo=timezone.utc))
+    await _seed_play_log(log_id="log_other_scn", user_id=42, scenario_id="s_2", completed_at=datetime(2026, 2, 1, tzinfo=timezone.utc))
+
+    resp = await internal_client.get(
+        "/api/internal/play-logs/user/42", params={"scenario_id": "s_1"}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    # 타 유저·타 시나리오 제외, completed_at desc
+    assert [r["log_id"] for r in body] == ["log_new", "log_old"]
+    assert body[0]["ending_type"] == "ending_bad"
+    assert body[0]["total_score"] == 42
+
+
+# ---- 상세 ----
+
+async def test_returns_ending_content_with_category(internal_client, test_db):
+    await _seed_scenario(scenario_id="s_1", with_category=True)
+    await _seed_play_log(log_id="log_1", user_id=42, scenario_id="s_1",
+                         completed_at=datetime(2026, 1, 1, tzinfo=timezone.utc))
+
+    resp = await internal_client.get(
+        "/api/internal/play-logs/log_1", params={"user_id": 42}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["log_id"] == "log_1"
+    assert body["image_url"] == "https://img/ending.png"
+    assert body["text"] == "결말 서술 텍스트"
+    assert body["ending_category"] == {"label": "피해 발생", "description": "자산을 잃었습니다"}
+
+
+async def test_other_user_returns_404(internal_client, test_db):
+    await _seed_scenario(scenario_id="s_1")
+    await _seed_play_log(log_id="log_1", user_id=99, scenario_id="s_1",
+                         completed_at=datetime(2026, 1, 1, tzinfo=timezone.utc))
+
+    resp = await internal_client.get(
+        "/api/internal/play-logs/log_1", params={"user_id": 42}
+    )
+    assert resp.status_code == 404
+
+
+async def test_nonexistent_log_returns_404(internal_client, test_db):
+    resp = await internal_client.get(
+        "/api/internal/play-logs/nope", params={"user_id": 42}
+    )
+    assert resp.status_code == 404
+
+
+async def test_missing_scenario_returns_404(internal_client, test_db):
+    # play_log 만 있고 scenario 없음 (하드삭제 시뮬)
+    await _seed_play_log(log_id="log_1", user_id=42, scenario_id="s_gone",
+                         completed_at=datetime(2026, 1, 1, tzinfo=timezone.utc))
+
+    resp = await internal_client.get(
+        "/api/internal/play-logs/log_1", params={"user_id": 42}
+    )
+    assert resp.status_code == 404
+
+
+async def test_category_none_omitted(internal_client, test_db):
+    await _seed_scenario(scenario_id="s_1", with_category=False)
+    await _seed_play_log(log_id="log_1", user_id=42, scenario_id="s_1",
+                         completed_at=datetime(2026, 1, 1, tzinfo=timezone.utc))
+
+    resp = await internal_client.get(
+        "/api/internal/play-logs/log_1", params={"user_id": 42}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ending_category"] is None
+    # 카테고리 없어도 결말 코어는 정상
+    assert body["image_url"] == "https://img/ending.png"
+    assert body["text"] == "결말 서술 텍스트"


### PR DESCRIPTION
## 관련 이슈
Closes #69 

## 개요
마이페이지 히스토리: 진행도 카드 → 시나리오별 플레이 기록 목록(L2) → 결말 상세(L3).
play 데이터는 game-engine(MongoDB) 정본, backend는 internal API로 조회(progress와 동일 경계).
game-engine internal + backend 공개 양쪽 수직 슬라이스.

## 공개 API
- `GET /api/v1/users/me/history/play-logs?scenarioId={id}` — 목록 (빈 결과 200 `[]`)
- `GET /api/v1/users/me/history/play-logs/{logId}` — 결말 상세 (사진 + 결말 텍스트 + 카테고리)

## 변경 사항
**game-engine (internal)**
- `GET /api/internal/play-logs/user/{userId}?scenario_id=` — 목록 (복합인덱스 (user_id, scenario_id), completed_at desc)
- `GET /api/internal/play-logs/{logId}?user_id=` — 상세. 소유 검증(타인/미존재 404), 결말 조립(nodes[final_node_id] image+text + ending_categories 매핑)
- 응답 스키마 3개 + pytest 7

**backend**
- `GameEngineClient`: `getPlayLogs`(broad→502), `getPlayLogDetail`(engine404→PLAY_LOG_NOT_FOUND / 그 외→502)
- internal ↔ 공개 DTO 분리
- `HistoryController` 공개 2개 (@AuthenticationPrincipal, ApiResponse, Swagger 200/401/404/502)
- `ErrorCode` +PLAY_LOG_NOT_FOUND(404)
- `HistoryServiceTest`: 매핑/빈목록 + 매핑/null category/404·502 passthrough

## 주요 설계 결정
- history read = game-engine 정본 단일화(Option 3). backend PG `play_logs`(요약)는 미사용
- 사진 + 결말 요약만 (per-choice 타임라인은 path 보존 → 무손실 연기)
- `find_one` 조회(Beanie `.get()`은 `_id`), 카테고리 None/dangling 방어
- 404 vs 502 정밀 구분(collapse 금지)

## 체크리스트
- [x] 코드 포맷팅(Checkstyle, Lint 등)을 적용하였는가?
- [x] 테스트 코드를 작성하고 통과했는가?
- [x] 불필요한 console.log / print 등을 제거했는가?
- [x] 로컬 테스트를 완료했는가?
- [ ] 관련 서비스 동작을 확인했는가?

## 테스트
- game-engine: `uv run pytest` 7 passed
- backend: `./gradlew build` green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 사용자의 플레이 로그 요약 목록 조회 기능 추가
  * 플레이 로그 상세 정보 조회 기능 추가 (결말 이미지, 텍스트, 카테고리 포함)
  * 플레이 기록 관련 오류 처리 로직 구성

<!-- end of auto-generated comment: release notes by coderabbit.ai -->