### PR TITLE
[FEAT] game-engine 결말 도달 시 backend 동기화(game-completed) 발신 구현 (#71)

### DIFF
--- a/apps/game-engine/.env.example
+++ b/apps/game-engine/.env.example
@@ -12,3 +12,6 @@ SCENARIOS_DIR=
 
 # JWT — backend-spring 이 발급한 토큰을 검증하기 위해 infra/.env 와 동일해야 함
 JWT_SECRET=local-jwt-secret-key-at-least-32-bytes-123
+
+# game-completed 발신 대상 backend base-url. 로컬은 backend 호스트 포트(8080). 배포 시 override.
+BACKEND_BASE_URL=http://localhost:8080

--- a/apps/game-engine/app/api/routes/game_sessions.py
+++ b/apps/game-engine/app/api/routes/game_sessions.py
@@ -10,10 +10,10 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from uuid import uuid4
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Response, status
 
 from app.core.auth import get_current_user
-from app.core.backend_client import GameCompletedPayload
+from app.core.backend_client import GameCompletedPayload, notify_game_completed
 from app.models.common import Resources
 from app.models.game_session import GameSession
 from app.models.play_log import PlayLog
@@ -373,6 +373,7 @@ async def get_session(
 async def make_move(
     session_id: str,
     body: MoveRequest,
+    background_tasks: BackgroundTasks,
     user: dict = Depends(get_current_user),
 ) -> MoveResponse:
     user_id = user["user_id"]
@@ -405,9 +406,10 @@ async def make_move(
             status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)
         ) from e
 
+    payload: GameCompletedPayload | None = None
     if result.is_finished:
         assert result.ending_type is not None
-        await _finalize_ending(
+        payload = await _finalize_ending(
             session,
             scenario,
             final_node_id=session.current_node_id,
@@ -416,6 +418,10 @@ async def make_move(
         )
 
     await session.save()
+
+    # backend 통계 동기화 발신 — 응답 후 백그라운드(best-effort, 실패해도 게임 완료는 성공)
+    if payload is not None:
+        background_tasks.add_task(notify_game_completed, payload)
 
     return _build_move_response(
         session,

--- a/apps/game-engine/app/api/routes/game_sessions.py
+++ b/apps/game-engine/app/api/routes/game_sessions.py
@@ -96,7 +96,8 @@ async def _finalize_ending(
     now: datetime,
 ) -> GameCompletedPayload:
     """ending 도달 시 부가 처리:
-    1. session.status = "completed", completed_at, visited_endings
+    1. session.status = "completed" 를 먼저 persist
+       (이후 문서 쓰기가 실패해도 세션이 playing 으로 남지 않게 → 이어하기 재완료로 인한 중복 집계 방지)
     2. PlayLog insert
     3. UserScenarioProgress upsert
 
@@ -106,6 +107,11 @@ async def _finalize_ending(
     session.completed_at = now
     if final_node_id not in session.visited_endings:
         session.visited_endings.append(final_node_id)
+
+    # completed 세션을 먼저 확정. 이후 PlayLog/progress 쓰기가 실패해도 세션이
+    # playing 이 아니므로 이어하기 대상에서 빠져 재 finalize(중복 집계)가 막힌다.
+    # 대가: 후속 쓰기 실패 시 그 판 기록 1회 유실 — 중복보다 안전한 트레이드오프.
+    await session.save()
 
     # 1) path 계산 (choices_history -> 각 node 의 choice index)
     path: list[int] = []
@@ -416,8 +422,8 @@ async def make_move(
             ending_type=result.ending_type,
             now=now,
         )
-
-    await session.save()
+    else:
+        await session.save()
 
     # backend 통계 동기화 발신 — 응답 후 백그라운드(best-effort, 실패해도 게임 완료는 성공)
     if payload is not None:

--- a/apps/game-engine/app/api/routes/game_sessions.py
+++ b/apps/game-engine/app/api/routes/game_sessions.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 
 from app.core.auth import get_current_user
+from app.core.backend_client import GameCompletedPayload
 from app.models.common import Resources
 from app.models.game_session import GameSession
 from app.models.play_log import PlayLog
@@ -93,11 +94,13 @@ async def _finalize_ending(
     final_node_id: str,
     ending_type: str,
     now: datetime,
-) -> None:
+) -> GameCompletedPayload:
     """ending 도달 시 부가 처리:
     1. session.status = "completed", completed_at, visited_endings
     2. PlayLog insert
     3. UserScenarioProgress upsert
+
+    backend 통계 동기화 발신용 payload 를 반환한다(HTTP 발신은 호출자 책임).
     """
     session.status = "completed"
     session.completed_at = now
@@ -132,8 +135,10 @@ async def _finalize_ending(
         0, session.resources.trust + session.resources.money + session.resources.awareness
     ) * 10
 
+    # Mongo log_id 와 backend play_log_id 를 동일 값으로 (멱등 정합)
+    log_id = uuid4().hex
     play_log = PlayLog(
-        log_id=uuid4().hex,
+        log_id=log_id,
         scenario_id=session.scenario_id,
         user_id=session.user_id,
         path=path,
@@ -156,16 +161,17 @@ async def _finalize_ending(
     )
     if existing_progress is None:
         discovered = [final_node_id]
+        completion_rate = (
+            len(discovered) / scenario.total_endings
+            if scenario.total_endings > 0
+            else 0.0
+        )
         progress = UserScenarioProgress(
             user_id=session.user_id,
             scenario_id=session.scenario_id,
             discovered_endings=discovered,
             total_endings=scenario.total_endings,
-            completion_rate=(
-                len(discovered) / scenario.total_endings
-                if scenario.total_endings > 0
-                else 0.0
-            ),
+            completion_rate=completion_rate,
             play_count=1,
             last_played_at=now,
         )
@@ -174,14 +180,30 @@ async def _finalize_ending(
         if final_node_id not in existing_progress.discovered_endings:
             existing_progress.discovered_endings.append(final_node_id)
         existing_progress.total_endings = scenario.total_endings
-        existing_progress.completion_rate = (
+        completion_rate = (
             len(existing_progress.discovered_endings) / scenario.total_endings
             if scenario.total_endings > 0
             else 0.0
         )
+        existing_progress.completion_rate = completion_rate
         existing_progress.play_count += 1
         existing_progress.last_played_at = now
         await existing_progress.save()
+
+    # 3) backend 발신용 payload (HTTP 발신은 move 핸들러가 best-effort 로 수행)
+    return GameCompletedPayload(
+        play_log_id=log_id,
+        user_id=session.user_id,
+        scenario_id=session.scenario_id,
+        session_id=session.session_id,
+        ending_type=ending_type,
+        final_node_id=final_node_id,
+        completion_rate=completion_rate,
+        total_score=total_score,
+        dangerous_count=session.dangerous_count,
+        duration_seconds=duration_seconds,
+        completed_at=now.isoformat(),
+    )
 
 
 # -------- routes --------

--- a/apps/game-engine/app/core/backend_client.py
+++ b/apps/game-engine/app/core/backend_client.py
@@ -1,0 +1,72 @@
+"""game-engine >> backend 발신 클라이언트 — 결말 도달 시 통계 동기화 POST.
+
+best-effort fire-and-forget: 실패해도 게임 완료는 항상 성공해야 하므로 모든 예외를
+흡수하고 warning 로그만 남긴다. 멱등키(play_log_id)로 backend 가 중복을 차단하므로
+재발신은 안전. backend 수신부: POST /api/internal/stats/game-completed.
+"""
+from __future__ import annotations
+
+import logging
+
+import httpx
+from pydantic import BaseModel
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+_ENDPOINT = "/api/internal/stats/game-completed"
+_TIMEOUT = httpx.Timeout(connect=2.0, read=3.0, write=3.0, pool=3.0)
+
+
+class GameCompletedPayload(BaseModel):
+    """backend GameCompletedRequest 계약과 1:1 (snake_case 키 동일).
+
+    game-engine 은 결말 도달 시 항상 구체 값을 채워 보내므로 모두 non-optional.
+    completed_at 은 UTC tz-aware ISO-8601 문자열(now.isoformat()).
+    """
+
+    play_log_id: str
+    user_id: int
+    scenario_id: str
+    session_id: str
+    ending_type: str
+    final_node_id: str
+    completion_rate: float
+    total_score: int
+    dangerous_count: int
+    duration_seconds: int
+    completed_at: str
+
+
+async def notify_game_completed(
+    payload: GameCompletedPayload,
+    *,
+    client: httpx.AsyncClient | None = None,
+) -> None:
+    """결말 동기화를 backend 로 발신(best-effort). 실패는 흡수 + warning 로그.
+
+    client 인자는 테스트에서 MockTransport 주입용(미주입 시 per-call 클라이언트 생성).
+    """
+    url = f"{settings.backend_base_url.rstrip('/')}{_ENDPOINT}"
+    headers = {"X-Internal-Api-Key": settings.internal_api_key}
+    body = payload.model_dump()
+
+    owns_client = client is None
+    if client is None:
+        client = httpx.AsyncClient(timeout=_TIMEOUT)
+    try:
+        resp = await client.post(url, json=body, headers=headers)
+        resp.raise_for_status()
+    except Exception as exc:
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        logger.warning(
+            "game-completed sync failed (status=%s play_log_id=%s user_id=%s)",
+            status,
+            payload.play_log_id,
+            payload.user_id,
+            exc_info=True,
+        )
+    finally:
+        if owns_client:
+            await client.aclose()

--- a/apps/game-engine/app/core/config.py
+++ b/apps/game-engine/app/core/config.py
@@ -33,6 +33,10 @@ class Settings(BaseSettings):
     internal_api_key: str = (
         "local-internal-api-key-at-least-16-bytes"
     )
+    
+    # game-engine >> backend 발신(POST /api/internal/stats/game-completed) 대상 base-url.
+    # 로컬은 backend 가 호스트 8080 에서 구동. 운영/배포는 BACKEND_BASE_URL 환경변수로 override.
+    backend_base_url: str = "http://localhost:8080"
 
 
 settings = Settings()  # type: ignore[call-arg]

--- a/apps/game-engine/pyproject.toml
+++ b/apps/game-engine/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "beanie>=2.0.0",
     "python-dotenv>=1.0.0",
     "pyjwt>=2.8.0",
+    "httpx>=0.27.0",
 ]
 
 [dependency-groups]
@@ -18,7 +19,6 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "testcontainers[mongodb]>=4.0",
-    "httpx>=0.27.0",
 ]
 
 [build-system]

--- a/apps/game-engine/tests/test_backend_client.py
+++ b/apps/game-engine/tests/test_backend_client.py
@@ -1,0 +1,63 @@
+"""backend_client 발신 테스트 — httpx.MockTransport 주입(전역 patch 회피).
+
+notify_game_completed 는 주입된 client 로만 동작하므로 Mongo 컨테이너/앱 기동 불필요.
+"""
+from __future__ import annotations
+
+import json
+
+import httpx
+
+from app.core.backend_client import GameCompletedPayload, notify_game_completed
+from app.core.config import settings
+
+
+def _payload() -> GameCompletedPayload:
+    return GameCompletedPayload(
+        play_log_id="log-abc",
+        user_id=1,
+        scenario_id="scenario_001",
+        session_id="sess-1",
+        ending_type="ending_good",
+        final_node_id="n_end_good",
+        completion_rate=1.0,
+        total_score=120,
+        dangerous_count=2,
+        duration_seconds=87,
+        completed_at="2026-06-05T05:40:58.123456+00:00",
+    )
+
+
+async def test_maps_request_to_internal_endpoint():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["api_key"] = request.headers.get("X-Internal-Api-Key")
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"unlocked_achievements": []})
+
+    payload = _payload()
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await notify_game_completed(payload, client=client)
+
+    assert captured["url"].endswith("/api/internal/stats/game-completed")
+    assert captured["api_key"] == settings.internal_api_key
+    assert captured["body"] == payload.model_dump()
+
+
+async def test_absorbs_non_2xx():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"message": "boom"})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        # best-effort: 예외 전파 없이 정상 반환해야 함
+        await notify_game_completed(_payload(), client=client)
+
+
+async def test_absorbs_connection_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await notify_game_completed(_payload(), client=client)

--- a/apps/game-engine/uv.lock
+++ b/apps/game-engine/uv.lock
@@ -198,6 +198,7 @@ source = { editable = "." }
 dependencies = [
     { name = "beanie" },
     { name = "fastapi" },
+    { name = "httpx" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyjwt" },
@@ -207,7 +208,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "testcontainers", extra = ["mongodb"] },
@@ -217,6 +217,7 @@ dev = [
 requires-dist = [
     { name = "beanie", specifier = ">=2.0.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "httpx", specifier = ">=0.27.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "pyjwt", specifier = ">=2.8.0" },
@@ -226,7 +227,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "httpx", specifier = ">=0.27.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
     { name = "testcontainers", extras = ["mongodb"], specifier = ">=4.0" },


### PR DESCRIPTION
## 관련 이슈
Closes #71 

## 변경 사항

**설정 · 의존성**
- `pyproject.toml`: `httpx`를 `[dependency-groups] dev` → `[project] dependencies`로 승격. 런타임 코드(`backend_client`)가 사용하므로 필수. `uv.lock`도 함께 재생성.
- `app/core/config.py`: `backend_base_url`(env `BACKEND_BASE_URL`, 기본 `http://localhost:8080`) 추가. 기존 `internal_api_key` 재사용.
- `.env.example`: `BACKEND_BASE_URL` + `INTERNAL_API_KEY` 추가(후자는 config엔 있는데 example에 누락돼 있던 gap).

**발신 클라이언트 (신규 `app/core/backend_client.py`)**
- `GameCompletedPayload`(pydantic): backend `GameCompletedRequest` 11필드와 1:1, snake_case 키 동일. game-engine은 결말 시 항상 구체 값을 채워 보내므로 전 필드 non-optional.
- `notify_game_completed(payload, *, client=None)`: best-effort fire-and-forget. `X-Internal-Api-Key` 헤더 + per-call `AsyncClient`(짧은 timeout). 모든 예외/타임아웃/non-2xx를 흡수하고 `warning` 로그만 남긴다(호출자에 전파 안 함). 응답(`unlocked_achievements`)은 미사용.

**발신 배선 (`app/api/routes/game_sessions.py`)**
- `_finalize_ending`: 순수 Mongo 처리는 그대로 두고, `GameCompletedPayload`를 **반환**하도록 변경. `log_id`를 `PlayLog` 생성 전에 hoist해 Mongo `log_id`와 payload `play_log_id`를 동일 값으로(멱등 정합), `completion_rate`를 두 upsert 분기에서 local로 캡처.
- `make_move`: `BackgroundTasks` 주입. 결말 시 payload를 받아 `session.save()` 후 `background_tasks.add_task(notify_game_completed, payload)`로 발신 → `/move` 응답은 즉시 반환, POST는 응답 후 백그라운드.
- 또한 completed 세션을 PlayLog/progress 쓰기 전에 persist — 후속 쓰기 실패 시 세션이 playing으로 남아 이어하기로 재완료되며 중복 집계되는 것을 방지(CodeRabbit Major 반영). 결말 경로는 finalize가, 비결말은 라우트가 session.save() 담당.

**테스트 (신규 `tests/test_backend_client.py`)**
- `httpx.MockTransport` 주입(전역 monkeypatch 회피). 매핑(URL/헤더/11필드) + best-effort(500·연결오류 흡수). 외부 의존 없어 Mongo 컨테이너 불필요.

## 설계 결정

- **best-effort**: stat sync 실패가 게임 완료를 막지 않는다.
- **응답 비차단**: `BackgroundTasks`로 POST를 응답 후 실행 → 결말 화면이 backend 상태와 무관하게 즉시 표시.
- **멱등/중복 방지**: backend는 play_log_id로 같은 payload 재전송을 차단한다. 단 session.save() 실패 후 이어하기로 재finalize되면 새 log_id가 생겨 이 멱등을 우회하므로, _finalize_ending이 completed 세션을 먼저 persist해 재finalize 자체를 막는다(playing 가드 활용).
- **동기 HTTP**: RabbitMQ 비동기는 케이스2(미래).
- `completed_at`은 UTC tz-aware ISO 문자열(`now.isoformat()`) — backend `FlexibleUtcDateTimeDeserializer`가 `OffsetDateTime.parse`로 수용(오프셋·마이크로초 포함). alias는 양쪽 다 snake_case라 불필요해 제거.

## 요청 계약 (GameCompletedPayload)

| 필드 | 출처 |
|---|---|
| `play_log_id` | hoist된 `log_id` |
| `user_id` | `session.user_id` |
| `scenario_id` | `session.scenario_id` |
| `session_id` | `session.session_id` |
| `ending_type` | `result.ending_type` (good/bad) |
| `final_node_id` | `session.current_node_id` |
| `completion_rate` | 캡처한 `completion_rate` |
| `total_score` | `_finalize_ending` local |
| `dangerous_count` | `session.dangerous_count` |
| `duration_seconds` | `_finalize_ending` local |
| `completed_at` | `now.isoformat()` |

## 테스트

- 단위: `uv run pytest tests/test_backend_client.py -q` (+ 기존 `test_game_sessions.py` 회귀). CI는 game-engine pytest 미게이트라 로컬 실행.
- 수동 E2E(DoD):
  - [] 로그인 → 게임 시작 → 결말 `/move` → 200, PG `play_logs`/`user_stats`/업적/알림 적재 확인.
  - [] backend 다운 상태에서 결말 `/move` → 여전히 200·지연 없음(백그라운드 흡수).
  - [] 동일 `play_log_id` 재발신 → backend 멱등(빈 결과).

## 트레이드오프

- `except Exception` 광범위 catch는 의도적 — best-effort라 어떤 실패도 게임 완료를 막으면 안 됨. 실패는 `status`/`play_log_id`/`user_id` + `exc_info`로 로깅.
- `BackgroundTasks` 특성상 실패가 사용자에게 비가시 → 로그가 유일 안전망(의도).
- 자동 재시도/outbox 없음 → 발신 실패 시 그 판 PG 동기화는 영구 유실(게임은 성공). 보강은 후속 이슈.
- 완료 처리는 "최대 1회" 보장: completed를 먼저 확정하므로 이후 PlayLog/progress(및 backend 발신) 쓰기가 실패하면 그 판 기록이 1회 유실될 수 있다(중복 집계보다 안전한 선택). 세 문서를 한 트랜잭션으로 묶는 정석은 Mongo replica set이 필요해 후속.

## 스코프 제외 (후속)

- 자동 재시도/outbox, RabbitMQ 무손실 비동기(케이스2)
- `unlocked_achievements`를 `MoveResponse`로 노출(즉시 토스트 UX) — 스키마+프론트 조율, 별도 이슈
- 공유 httpx client(lifespan) 최적화
- `GameEngineClientTest`/E2E 와이어 자동 검증(#69 후속)

## 체크리스트
- [x] 코드 포맷팅(Checkstyle, Lint 등)을 적용하였는가?
- [x] 테스트 코드를 작성하고 통과했는가?
- [x] 불필요한 console.log / print 등을 제거했는가?
- [x] 로컬 테스트를 완료했는가?
- [ ] 관련 서비스 동작을 확인했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 게임 완료 시 백엔드 통계가 자동으로 동기화됩니다. 게임 진행도와 플레이 기록이 더욱 정확하게 기록됩니다.

* **테스트**
  * 백엔드 통계 동기화 기능에 대한 테스트 케이스가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->