### PR TITLE
[FEAT] 결말 수집 진행도 기준을 결말 노드 수 → 결말 유형 수로 변경 (#75)

### DIFF
--- a/apps/backend/src/main/java/com/sos/backend/domain/history/dto/response/ScenarioProgressResponse.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/history/dto/response/ScenarioProgressResponse.java
@@ -7,16 +7,16 @@ import java.time.LocalDateTime;
 public record ScenarioProgressResponse(
     String scenarioId,
     double completionRate,
-    int discoveredCount,
-    int totalEndings,
+    int discoveredCategoryCount,
+    int totalCategories,
     LocalDateTime lastPlayedAt
 ) {
     public static ScenarioProgressResponse from(ScenarioProgressInternalResponse internal) {
         return new ScenarioProgressResponse(
             internal.scenarioId(),
             internal.completionRate(),
-            internal.discoveredCount(),
-            internal.totalEndings(),
+            internal.discoveredCategoryCount(),
+            internal.totalCategories(),
             internal.lastPlayedAt()
         );
     }

--- a/apps/backend/src/main/java/com/sos/backend/global/internal/dto/ScenarioProgressInternalResponse.java
+++ b/apps/backend/src/main/java/com/sos/backend/global/internal/dto/ScenarioProgressInternalResponse.java
@@ -11,8 +11,8 @@ import java.time.LocalDateTime;
 public record ScenarioProgressInternalResponse(
     String scenarioId,
     double completionRate,
-    int discoveredCount,
-    int totalEndings,
+    int discoveredCategoryCount,
+    int totalCategories,
     @JsonDeserialize(using = FlexibleUtcDateTimeDeserializer.class)
     LocalDateTime lastPlayedAt
 ) {

--- a/apps/backend/src/test/java/com/sos/backend/domain/history/service/HistoryServiceTest.java
+++ b/apps/backend/src/test/java/com/sos/backend/domain/history/service/HistoryServiceTest.java
@@ -45,8 +45,8 @@ class HistoryServiceTest {
         assertThat(result).hasSize(1);
         assertThat(result.get(0).scenarioId()).isEqualTo("scenario_5d6e8982");
         assertThat(result.get(0).completionRate()).isEqualTo(0.0138);
-        assertThat(result.get(0).discoveredCount()).isEqualTo(3);
-        assertThat(result.get(0).totalEndings()).isEqualTo(217);
+        assertThat(result.get(0).discoveredCategoryCount()).isEqualTo(3);
+        assertThat(result.get(0).totalCategories()).isEqualTo(217);
         assertThat(result.get(0).lastPlayedAt()).isEqualTo(LocalDateTime.of(2026,4,1,14,30,0));
     }
 

--- a/apps/frontend/src/features/history/components/HistoryTab.tsx
+++ b/apps/frontend/src/features/history/components/HistoryTab.tsx
@@ -158,16 +158,16 @@ function ScenarioProgressCard({
       <div className="mt-4 space-y-2">
         <div className="flex items-center justify-between text-xs text-slate-400">
           <span>
-            결말 수집 {progress.discoveredCount}/{progress.totalEndings}
+            결말 유형 수집 {progress.discoveredCategoryCount}/{progress.totalCategories}
           </span>
           <span className="tabular-nums">{rate}%</span>
         </div>
         <div
           role="progressbar"
-          aria-label="결말 수집도"
-          aria-valuenow={progress.discoveredCount}
+          aria-label="결말 유형 수집도"
+          aria-valuenow={progress.discoveredCategoryCount}
           aria-valuemin={0}
-          aria-valuemax={progress.totalEndings}
+          aria-valuemax={progress.totalCategories}
           className="h-2 overflow-hidden rounded-full bg-slate-800"
         >
           <div className="h-full rounded-full bg-emerald-400" style={{ width: `${rate}%` }} />

--- a/apps/frontend/src/features/history/types.ts
+++ b/apps/frontend/src/features/history/types.ts
@@ -3,8 +3,8 @@
 export type ScenarioProgress = {
   scenarioId: string
   completionRate: number // 0.0 ~ 1.0
-  discoveredCount: number
-  totalEndings: number
+  discoveredCategoryCount: number
+  totalCategories: number
   lastPlayedAt: string // ISO 8601
 }
 

--- a/apps/game-engine/app/api/routes/game_sessions.py
+++ b/apps/game-engine/app/api/routes/game_sessions.py
@@ -160,35 +160,44 @@ async def _finalize_ending(
     )
     await play_log.insert()
 
-    # 2) progress upsert
+    # 2) progress upsert (결말 유형 category 기준)
+    #    도달 노드의 ending_category 를 수집. 분모 = 시나리오 결말 유형 수.
+    #    ending_categories 미분류(None)거나 dangling 카테고리면 수집 제외(rate 0 폴백).
+    final_node = scenario.nodes.get(final_node_id)
+    category_id = final_node.ending_category if final_node else None
+    ending_categories = scenario.ending_categories or {}
+    total_categories = len(ending_categories)
+    is_valid_category = bool(category_id and category_id in ending_categories)
+
     existing_progress = await UserScenarioProgress.find_one(
         UserScenarioProgress.user_id == session.user_id,
         UserScenarioProgress.scenario_id == session.scenario_id,
     )
     if existing_progress is None:
-        discovered = [final_node_id]
+        discovered = [category_id] if is_valid_category else []
         completion_rate = (
-            len(discovered) / scenario.total_endings
-            if scenario.total_endings > 0
-            else 0.0
+            len(discovered) / total_categories if total_categories > 0 else 0.0
         )
         progress = UserScenarioProgress(
             user_id=session.user_id,
             scenario_id=session.scenario_id,
-            discovered_endings=discovered,
-            total_endings=scenario.total_endings,
+            discovered_categories=discovered,
+            total_categories=total_categories,
             completion_rate=completion_rate,
             play_count=1,
             last_played_at=now,
         )
         await progress.insert()
     else:
-        if final_node_id not in existing_progress.discovered_endings:
-            existing_progress.discovered_endings.append(final_node_id)
-        existing_progress.total_endings = scenario.total_endings
+        if (
+            is_valid_category
+            and category_id not in existing_progress.discovered_categories
+        ):
+            existing_progress.discovered_categories.append(category_id)
+        existing_progress.total_categories = total_categories
         completion_rate = (
-            len(existing_progress.discovered_endings) / scenario.total_endings
-            if scenario.total_endings > 0
+            len(existing_progress.discovered_categories) / total_categories
+            if total_categories > 0
             else 0.0
         )
         existing_progress.completion_rate = completion_rate

--- a/apps/game-engine/app/api/routes/internal.py
+++ b/apps/game-engine/app/api/routes/internal.py
@@ -41,10 +41,8 @@ async def list_user_progress(user_id: int) -> list[ScenarioProgressResponse]:
         ScenarioProgressResponse(
             scenario_id=r.scenario_id,
             completion_rate=r.completion_rate,
-            # Phase 1: 모델은 category 기준. 응답 키(discovered_count/total_endings)는
-            # Phase 2 에서 리네임 — 여기선 값만 유형 기준으로 흐름.
-            discovered_count=len(r.discovered_categories),
-            total_endings=r.total_categories,
+            discovered_category_count=len(r.discovered_categories),
+            total_categories=r.total_categories,
             last_played_at=r.last_played_at,
         )
         for r in rows

--- a/apps/game-engine/app/api/routes/internal.py
+++ b/apps/game-engine/app/api/routes/internal.py
@@ -41,8 +41,10 @@ async def list_user_progress(user_id: int) -> list[ScenarioProgressResponse]:
         ScenarioProgressResponse(
             scenario_id=r.scenario_id,
             completion_rate=r.completion_rate,
-            discovered_count=len(r.discovered_endings),
-            total_endings=r.total_endings,
+            # Phase 1: 모델은 category 기준. 응답 키(discovered_count/total_endings)는
+            # Phase 2 에서 리네임 — 여기선 값만 유형 기준으로 흐름.
+            discovered_count=len(r.discovered_categories),
+            total_endings=r.total_categories,
             last_played_at=r.last_played_at,
         )
         for r in rows

--- a/apps/game-engine/app/models/user_scenario_progress.py
+++ b/apps/game-engine/app/models/user_scenario_progress.py
@@ -9,14 +9,16 @@ from pymongo import ASCENDING, IndexModel
 class UserScenarioProgress(Document):
     """(user_id, scenario_id) 복합 유니크.
 
-    total_endings는 scenarios.total_endings의 denorm.
-    completion_rate = len(discovered_endings) / total_endings.
+    결말 **유형(ending_category)** 기준 수집 진행도.
+    discovered_categories: 도달한 distinct ending_category id 목록.
+    total_categories: 시나리오 결말 유형 수 (len(scenario.ending_categories)).
+    completion_rate = len(discovered_categories) / total_categories.
     """
 
     user_id: int
     scenario_id: str
-    discovered_endings: list[str] = Field(default_factory=list)
-    total_endings: int
+    discovered_categories: list[str] = Field(default_factory=list)
+    total_categories: int
     completion_rate: float = 0.0
     play_count: int = 0
     last_played_at: datetime

--- a/apps/game-engine/app/schemas/game.py
+++ b/apps/game-engine/app/schemas/game.py
@@ -107,14 +107,15 @@ class MoveResponse(BaseModel):
 class ScenarioProgressResponse(BaseModel):
     """internal: GET /api/internal/progress/{user_id} 응답 항목.
 
-    유저가 결말을 1개 이상 도달한 시나리오만 (progress 문서 존재 = finalize 발생).
-    snake_case 유지 (contract, alias 금지). discovered_count 는 계산값.
+    결말 **유형(ending_category)** 기준 수집 진행도. 유저가 결말 1개 이상 도달한
+    시나리오만 (progress 문서 존재 = finalize 발생). snake_case 유지 (contract, alias 금지).
+    discovered_category_count 는 계산값(len(discovered_categories)).
     """
 
     scenario_id: str
     completion_rate: float
-    discovered_count: int
-    total_endings: int
+    discovered_category_count: int
+    total_categories: int
     last_played_at: datetime
 
 class PlayLogSummaryResponse(BaseModel):

--- a/apps/game-engine/app/scripts/seed.py
+++ b/apps/game-engine/app/scripts/seed.py
@@ -83,6 +83,9 @@ def _to_scenario_doc(raw: dict[str, Any]) -> Scenario:
         total_endings=total,
         total_good_endings=good,
         total_bad_endings=bad,
+        # ending_classifier 결과 보존 — 누락 시 재시드가 ending_categories 를 None 으로
+        # 덮어써 유형 기준 진행도가 조용히 죽음(total 0 → rate 0). ai-pipeline 미러와 동일 컬렉션.
+        ending_categories=raw.get("ending_categories"),
         tags=raw.get("tags", []),
         created_at=raw["created_at"],
         updated_at=now,
@@ -325,20 +328,31 @@ async def _upsert_by_key(model_cls, key_field: str, doc) -> None:
 
 async def _upsert_progress(
     scenario_raw: dict[str, Any],
-    discovered: list[str],
+    discovered_node_ids: list[str],
     now: datetime,
 ) -> None:
-    """user_scenario_progress upsert."""
-    total, _, _ = _derive_ending_counts(scenario_raw["nodes"])
-    rate = len(discovered) / total if total > 0 else 0.0
+    """user_scenario_progress upsert (결말 유형 category 기준).
+
+    도달 결말 노드(discovered_node_ids)를 node.ending_category 로 매핑해 distinct 유형 수집.
+    분모 = 시나리오 결말 유형 수(len(ending_categories)). 미분류/dangling 카테고리는 제외.
+    """
+    nodes = scenario_raw["nodes"]
+    ending_categories = scenario_raw.get("ending_categories") or {}
+    total = len(ending_categories)
+    discovered_categories: list[str] = []
+    for node_id in discovered_node_ids:
+        cat = (nodes.get(node_id) or {}).get("ending_category")
+        if cat and cat in ending_categories and cat not in discovered_categories:
+            discovered_categories.append(cat)
+    rate = len(discovered_categories) / total if total > 0 else 0.0
     existing = await UserScenarioProgress.find_one(
         {"user_id": EXAMPLE_USER_ID, "scenario_id": _scenario_id(scenario_raw)}
     )
     doc = UserScenarioProgress(
         user_id=EXAMPLE_USER_ID,
         scenario_id=_scenario_id(scenario_raw),
-        discovered_endings=discovered,
-        total_endings=total,
+        discovered_categories=discovered_categories,
+        total_categories=total,
         completion_rate=rate,
         play_count=1,
         last_played_at=now,

--- a/apps/game-engine/tests/fixtures/regression_scenario.py
+++ b/apps/game-engine/tests/fixtures/regression_scenario.py
@@ -31,6 +31,7 @@ from app.models.common import (
     Choice,
     DangerFeedback,
     EducationalContent,
+    EndingCategory,
     ResourceDelta,
     ScenarioNode,
 )
@@ -169,7 +170,21 @@ def build_regression_scenario() -> Scenario:
         total_endings=2,
         total_good_endings=1,
         total_bad_endings=1,
-        ending_categories=None,
+        # 결말 유형 2종 (노드의 ending_category 와 일치). 유형 기준 진행도 검증용.
+        ending_categories={
+            "smart_block": EndingCategory(
+                category_id="smart_block",
+                label="스마트 차단",
+                description="피싱을 알아채고 차단했다.",
+                node_ids=["n_end_good"],
+            ),
+            "financial_loss": EndingCategory(
+                category_id="financial_loss",
+                label="금전 피해",
+                description="피해를 입었다.",
+                node_ids=["n_end_bad"],
+            ),
+        },
         tags=[],
         created_at=_NOW,
         updated_at=_NOW,

--- a/apps/game-engine/tests/test_game_sessions.py
+++ b/apps/game-engine/tests/test_game_sessions.py
@@ -206,10 +206,84 @@ async def test_move_reaching_ending_finalizes_session_and_records_log_progress(
         UserScenarioProgress.scenario_id == REGRESSION_SCENARIO_ID,
     )
     assert progress is not None
-    assert progress.discovered_endings == ["n_end_good"]
+    assert progress.discovered_categories == ["smart_block"]
     assert progress.play_count == 1
-    assert progress.total_endings == 2  # scenario.total_endings
+    assert progress.total_categories == 2  # 결말 유형 수 (smart_block, financial_loss)
+    assert progress.completion_rate == 0.5  # 1/2 유형
+
+
+async def _play_to_ending(
+    client: httpx.AsyncClient, scenario_id: str, second_choice: str
+) -> httpx.Response:
+    """n0_c1 → {second_choice} 로 결말까지. second_choice=n1_c1(good)/n1_c2(bad)."""
+    create = await client.post(
+        "/api/v1/game-sessions", json={"scenario_id": scenario_id}
+    )
+    sid = create.json()["session_id"]
+    await client.post(
+        f"/api/v1/game-sessions/{sid}/move", json={"choice_id": "n0_c1"}
+    )
+    res = await client.post(
+        f"/api/v1/game-sessions/{sid}/move", json={"choice_id": second_choice}
+    )
+    assert res.json()["is_finished"] is True
+    return res
+
+
+async def test_progress_full_collection_reaches_rate_1(
+    client: httpx.AsyncClient, _seeded_scenario
+):
+    """서로 다른 유형 2종 모두 도달 → completion_rate 1.0 (FULL_COLLECTION 조건)."""
+    await _play_to_ending(client, REGRESSION_SCENARIO_ID, "n1_c1")  # smart_block
+    await _play_to_ending(client, REGRESSION_SCENARIO_ID, "n1_c2")  # financial_loss
+
+    progress = await UserScenarioProgress.find_one(
+        UserScenarioProgress.user_id == 42,
+        UserScenarioProgress.scenario_id == REGRESSION_SCENARIO_ID,
+    )
+    assert sorted(progress.discovered_categories) == ["financial_loss", "smart_block"]
+    assert progress.total_categories == 2
+    assert progress.completion_rate == 1.0
+    assert progress.play_count == 2
+
+
+async def test_progress_dedup_same_category(
+    client: httpx.AsyncClient, _seeded_scenario
+):
+    """같은 유형 재도달 → discovered 중복 없음, rate 유지, play_count만 증가."""
+    await _play_to_ending(client, REGRESSION_SCENARIO_ID, "n1_c1")  # smart_block
+    await _play_to_ending(client, REGRESSION_SCENARIO_ID, "n1_c1")  # smart_block 재도달
+
+    progress = await UserScenarioProgress.find_one(
+        UserScenarioProgress.user_id == 42,
+        UserScenarioProgress.scenario_id == REGRESSION_SCENARIO_ID,
+    )
+    assert progress.discovered_categories == ["smart_block"]
+    assert progress.total_categories == 2
     assert progress.completion_rate == 0.5
+    assert progress.play_count == 2
+
+
+async def test_progress_fallback_when_scenario_has_no_categories(
+    client: httpx.AsyncClient, test_db
+):
+    """ending_categories=None 시나리오 → 수집 제외, total 0, rate 0.0, 크래시 없음."""
+    s = build_regression_scenario()
+    s.scenario_id = "regression_no_cats"
+    s.ending_categories = None
+    await s.insert()
+
+    res = await _play_to_ending(client, "regression_no_cats", "n1_c1")
+    assert res.status_code == 200
+
+    progress = await UserScenarioProgress.find_one(
+        UserScenarioProgress.user_id == 42,
+        UserScenarioProgress.scenario_id == "regression_no_cats",
+    )
+    assert progress is not None
+    assert progress.discovered_categories == []
+    assert progress.total_categories == 0
+    assert progress.completion_rate == 0.0
 
 
 async def test_move_invalid_choice_id_returns_400(

--- a/apps/game-engine/tests/test_internal_progress.py
+++ b/apps/game-engine/tests/test_internal_progress.py
@@ -1,0 +1,110 @@
+"""internal /progress 엔드포인트 — 유저 시나리오별 결말 유형 수집 진행도.
+
+auth(X-Internal-Api-Key)는 test_internal_auth.py 가 책임 → 여기선 verify_internal_api_key 를
+override 하고 응답 계약(유형 기준 필드·정렬·빈목록)만 검증한다.
+internal 라우터는 conftest 의 app_for_routes 에 없어 전용 app·client fixture 를 둔다.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+
+from app.api.routes import internal as internal_routes
+from app.core.internal_auth import verify_internal_api_key
+from app.models.user_scenario_progress import UserScenarioProgress
+
+
+@pytest.fixture
+def internal_app(test_db) -> FastAPI:
+    app = FastAPI()
+    app.include_router(internal_routes.router, prefix="/api/internal")
+    app.dependency_overrides[verify_internal_api_key] = lambda: None
+    return app
+
+
+@pytest_asyncio.fixture
+async def internal_client(internal_app: FastAPI):
+    transport = httpx.ASGITransport(app=internal_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    internal_app.dependency_overrides.clear()
+
+
+async def _seed_progress(
+    *,
+    user_id: int,
+    scenario_id: str,
+    discovered_categories: list[str],
+    total_categories: int,
+    completion_rate: float,
+    last_played_at: datetime,
+) -> None:
+    await UserScenarioProgress(
+        user_id=user_id,
+        scenario_id=scenario_id,
+        discovered_categories=discovered_categories,
+        total_categories=total_categories,
+        completion_rate=completion_rate,
+        play_count=1,
+        last_played_at=last_played_at,
+    ).insert()
+
+
+async def test_progress_serializes_category_fields(internal_client, test_db):
+    """응답이 유형 기준 필드(discovered_category_count/total_categories)로 직렬화."""
+    await _seed_progress(
+        user_id=7,
+        scenario_id="sc1",
+        discovered_categories=["c1", "c2"],
+        total_categories=10,
+        completion_rate=0.2,
+        last_played_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+    )
+
+    res = await internal_client.get("/api/internal/progress/7")
+    assert res.status_code == 200
+    body = res.json()
+    assert len(body) == 1
+    item = body[0]
+    assert item["scenario_id"] == "sc1"
+    assert item["completion_rate"] == 0.2
+    assert item["discovered_category_count"] == 2  # len(discovered_categories)
+    assert item["total_categories"] == 10
+    # 구 키는 제거됨
+    assert "discovered_count" not in item
+    assert "total_endings" not in item
+
+
+async def test_progress_empty_returns_200_empty_list(internal_client, test_db):
+    res = await internal_client.get("/api/internal/progress/999")
+    assert res.status_code == 200
+    assert res.json() == []
+
+
+async def test_progress_sorted_by_last_played_desc(internal_client, test_db):
+    older = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    newer = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    await _seed_progress(
+        user_id=7,
+        scenario_id="old",
+        discovered_categories=["c1"],
+        total_categories=10,
+        completion_rate=0.1,
+        last_played_at=older,
+    )
+    await _seed_progress(
+        user_id=7,
+        scenario_id="new",
+        discovered_categories=["c1", "c2"],
+        total_categories=10,
+        completion_rate=0.2,
+        last_played_at=newer,
+    )
+
+    res = await internal_client.get("/api/internal/progress/7")
+    assert res.status_code == 200
+    assert [i["scenario_id"] for i in res.json()] == ["new", "old"]

--- a/apps/game-engine/tests/test_seed.py
+++ b/apps/game-engine/tests/test_seed.py
@@ -1,0 +1,62 @@
+"""seed.py 회귀 가드 — ending_categories 보존 + 유형 기준 예시 progress.
+
+seed 는 전용 pytest 하니스가 없어 여기서 핵심 2가지를 잠근다:
+1. _to_scenario_doc 가 ending_categories 를 보존(재시드 시 None clobber 회귀 방지).
+   → ai-pipeline 미러와 같은 sos_db.scenarios 를 공유하므로, 이게 누락되면 재시드가
+     건강한 ending_categories 를 None 으로 덮어써 유형 기준 진행도가 조용히 죽는다(total 0).
+2. _upsert_progress 가 결말 노드 → distinct 유형(category) 으로 매핑.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from app.models.user_scenario_progress import UserScenarioProgress
+from app.scripts.seed import EXAMPLE_USER_ID, _to_scenario_doc, _upsert_progress
+
+_RAW = {
+    "scenario_id": "seed_test",
+    "title": "t",
+    "description": "d",
+    "phishing_type": "smishing",
+    "difficulty": "easy",
+    "root_node_id": "n0",
+    "nodes": {
+        "n0": {"id": "n0", "type": "narrative", "text": "x", "choices": []},
+        "e1": {
+            "id": "e1", "type": "ending_good", "text": "x",
+            "choices": [], "ending_category": "C1",
+        },
+        "e2": {
+            "id": "e2", "type": "ending_bad", "text": "y",
+            "choices": [], "ending_category": "C2",
+        },
+    },
+    "ending_categories": {
+        "C1": {"category_id": "C1", "label": "L1", "description": "D1", "node_ids": ["e1"]},
+        "C2": {"category_id": "C2", "label": "L2", "description": "D2", "node_ids": ["e2"]},
+    },
+    "created_at": datetime(2026, 1, 1, tzinfo=UTC),
+    "tags": [],
+}
+
+
+async def test_to_scenario_doc_preserves_ending_categories(test_db):
+    """🔴 회귀 가드: _to_scenario_doc 가 ending_categories 를 None 으로 떨구지 않음."""
+    doc = _to_scenario_doc(_RAW)
+    assert doc.ending_categories is not None
+    assert set(doc.ending_categories.keys()) == {"C1", "C2"}
+    assert doc.total_endings == 2  # 노드 수(ScenarioSummary)는 그대로 유지
+
+
+async def test_upsert_progress_maps_node_ids_to_categories(test_db):
+    """예시 progress: 결말 노드 → distinct 유형, total=유형 수, rate=유형 기준."""
+    await _upsert_progress(_RAW, ["e1"], datetime(2026, 6, 1, tzinfo=UTC))
+
+    p = await UserScenarioProgress.find_one(
+        UserScenarioProgress.user_id == EXAMPLE_USER_ID,
+        UserScenarioProgress.scenario_id == "seed_test",
+    )
+    assert p is not None
+    assert p.discovered_categories == ["C1"]
+    assert p.total_categories == 2
+    assert p.completion_rate == 0.5


### PR DESCRIPTION
## 관련 이슈
Closes #75 

## 요약
시나리오 수집 진행도(`completion_rate`)를 **결말 노드 수 → 결말 유형(ending_category) 수** 기준으로 전환.
시나리오당 ending 노드가 ~240개라 100% 수집이 불가능했고 `FULL_COLLECTION`(임계값 1.0) 업적도 달성 불가였음.
유형 10개(모든 ending 노드 분류 완료, distinct 10) 기준으로 → **10/10=1.0 달성 가능**. (팀 협의 결정)

## 변경
**game-engine**
- `UserScenarioProgress` 필드 리네임: `discovered_endings/total_endings` → `discovered_categories/total_categories`
- `_finalize_ending`: 도달 노드 → distinct `ending_category` 계산 (유효성 가드 `in ending_categories`, dedup, `ending_categories=None` 폴백 rate 0.0·무크래시), upsert 두 분기
- internal `/progress` 응답 + `ScenarioProgressResponse` 스키마 리네임 (`discovered_category_count`/`total_categories`, snake 유지)
- seed `_upsert_progress` 유형 기준 + 새 필드명

**backend** (필드명 리네임만, 로직 0)
- 진행도 DTO 2개(`ScenarioProgressInternalResponse`, history `ScenarioProgressResponse` + `from()`) 리네임
- 무변경: `StatsSyncService`·`AchievementService`·`completion_rate` 소비·`FULL_COLLECTION` 임계값 `1.0`
- Postgres `UserScenarioProgress`(미사용·빈 테이블) 미변경 — write/read-dead라 범위 밖, Flyway 불요

**frontend**
- history 타입 + `HistoryTab` 5곳 리네임 + 라벨/aria "결말 유형 수집"

**🔴 seed 회귀 fix**
- `_to_scenario_doc`가 `ending_categories`를 보존하도록 한 줄 추가. ai-pipeline 미러와 `sos_db.scenarios` 공유라, 누락 시 재시드(`uv run python -m app.scripts.seed`)가 건강한 `ending_categories`를 None으로 덮어써 진행도가 **조용히 죽던** 잠재 버그 차단. 회귀 가드 테스트 포함.

## ⚠️ 머지 후 1회 (ACTION REQUIRED)
필드 리네임으로 **구 스키마(노드기준) progress 문서는 read 시 ValidationError**(필수 `total_categories` 부재).
`/progress`는 `find(...).to_list()`라 구 문서 1건만 있어도 **그 유저 진행도 응답 전체가 500**(→backend 502→history 탭 파손).

플레이 이력 있는 로컬/공유 DB는 **pull 후 1회**:
```
mongosh
use sos_db          # game-engine의 MONGO_DB (라이브 확인값 sos_db)
db.user_scenario_progress.drop()
```
pre-launch·실유저 0이라 drop으로 충분(다음 플레이부터 유형 기준 문서 자동 생성).
※※※ 대상은 MongoDB 컬렉션(game-engine 소유). 백엔드 Postgres 테이블이 아님.
※ 구(미수정) seed는 돌리지 말 것 — 이 PR의 fix 반영본만 사용.
※ 운영 cutover라면 drop 아니라 `node→category` 재계산 migration 필요 — 현재 해당 없음.

## 프론트 수정 (lockstep — 같은 PR에 포함)
progress wire 필드 rename: `discoveredCount/totalEndings` → `discoveredCategoryCount/totalCategories`.
game-engine(snake) → backend `@JsonNaming` → frontend(camelCase)까지 한 PR에서 정렬 → **develop 안 깨짐.**

## 검증
- game-engine pytest **72 passed** (full-collection→1.0 / dedup / None 폴백 / seed 회귀 가드 신규)
- backend `./gradlew build` **SUCCESS**
- frontend `tsc -b` **클린**

## 체크리스트
- [x] 코드 포맷팅(Checkstyle, Lint 등)을 적용하였는가?
- [x] 테스트 코드를 작성하고 통과했는가?
- [x] 불필요한 console.log / print 등을 제거했는가?
- [x] 로컬 테스트를 완료했는가?
- [ ] 관련 서비스 동작을 확인했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 시나리오 진행도 추적 방식을 엔딩 개수에서 엔딩 카테고리 개수 기반으로 변경했습니다.
  * 사용자 인터페이스의 진행 표시 내용을 "결말 수집"에서 "결말 유형 수집"으로 업데이트했습니다.
  * 진행도 조회 API 응답 필드를 카테고리 기반으로 재구성했습니다.

* **Tests**
  * 새로운 엔딩 카테고리 기반 진행도 검증 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->