### PR TITLE
[Refactor]  통계 인사이트 시각화 및 마이페이지, 로비 UX 개선

### DIFF
--- a/apps/backend/src/main/java/com/sos/backend/domain/achievement/dto/AchievementResponse.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/achievement/dto/AchievementResponse.java
@@ -30,12 +30,22 @@ public record AchievementResponse(
 
     @Schema(description = "달성 시각 (미달성이면 null)")
     @JsonProperty("achieved_at")
-    LocalDateTime achievedAt
+    LocalDateTime achievedAt,
+
+    @Schema(description = "누적 진행 수치. 누적 N/M 이 불가한 업적(FLAWLESS·FULL_COLLECTION)은 null", example = "3")
+    @JsonProperty("progress_current")
+    Integer progressCurrent,
+
+    @Schema(description = "달성 임계값. 누적 N/M 이 불가한 업적은 null", example = "5")
+    @JsonProperty("progress_target")
+    Integer progressTarget
 ) {
-    public static AchievementResponse of(Achievement a, LocalDateTime achievedAt) {
+    public static AchievementResponse of(
+        Achievement a, LocalDateTime achievedAt, Integer progressCurrent, Integer progressTarget
+    ) {
         return new AchievementResponse(
             a.getAchievementId(), a.getCode(), a.getTitle(), a.getDescription(), a.getIconUrl(),
-            achievedAt != null, achievedAt
+            achievedAt != null, achievedAt, progressCurrent, progressTarget
         );
     }
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/achievement/service/AchievementService.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/achievement/service/AchievementService.java
@@ -7,6 +7,8 @@ import com.sos.backend.domain.achievement.entity.UserAchievement;
 import com.sos.backend.domain.achievement.repository.AchievementRepository;
 import com.sos.backend.domain.achievement.repository.UserAchievementRepository;
 import com.sos.backend.domain.user.entity.User;
+import com.sos.backend.domain.user.entity.UserStat;
+import com.sos.backend.domain.user.repository.UserStatRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -28,6 +30,7 @@ public class AchievementService {
 
     private final AchievementRepository achievementRepository;
     private final UserAchievementRepository userAchievementRepository;
+    private final UserStatRepository userStatRepository;
 
     @Transactional
     public List<Achievement> evaluateAndGrant(User user, AchievementContext ctx) {
@@ -54,17 +57,55 @@ public class AchievementService {
         return newlyGranted;
     }
 
-    /** 사용자의 전체 업적 목록(보유/미보유)을 반환한다. */
+    /** 사용자의 전체 업적 목록(보유/미보유)을 진행 수치와 함께 반환한다. */
     public List<AchievementResponse> getMyAchievements(Long userId) {
         Map<Long, LocalDateTime> achievedAtById = userAchievementRepository.findByUserIdWithAchievement(userId).stream()
             .collect(Collectors.toMap(
                 ua -> ua.getAchievement().getAchievementId(),
                 UserAchievement::getAchievedAt
             ));
+        UserStat stat = userStatRepository.findByUserId(userId).orElse(null);
 
         return achievementRepository.findAll().stream()
-            .map(a -> AchievementResponse.of(a, achievedAtById.get(a.getAchievementId())))
+            .map(a -> {
+                ProgressView progress = computeProgress(a.getCode(), a.getConditionValue(), stat);
+                return AchievementResponse.of(
+                    a, achievedAtById.get(a.getAchievementId()), progress.current(), progress.target());
+            })
             .toList();
+    }
+
+    /**
+     * 업적 code 별 누적 진행 수치(current/target). {@link #isSatisfied} 의 평가축과 1:1 로 매핑한다.
+     * 누적 N/M 이 성립하지 않는 FLAWLESS(per-play)·FULL_COLLECTION(per-scenario) 은 (null, null) 로 둔다.
+     * 새 업적 추가 시 isSatisfied 와 이 매핑을 함께 갱신한다.
+     */
+    private ProgressView computeProgress(String code, String conditionValue, UserStat stat) {
+        int completePlays = stat != null ? stat.getCompletePlays() : 0;
+        int goodEndings = stat != null ? stat.getGoodEndings() : 0;
+        try {
+            return switch (code) {
+                case "FIRST_CLEAR", "PLAY_10", "PLAY_30" ->
+                    ProgressView.of(completePlays, Integer.parseInt(conditionValue));
+                case "GOOD_ENDING_5" ->
+                    ProgressView.of(goodEndings, Integer.parseInt(conditionValue));
+                default -> ProgressView.none(); // FLAWLESS, FULL_COLLECTION 등 누적 N/M 불가
+            };
+        } catch (NumberFormatException e) {
+            log.warn("Invalid condition_value '{}' for achievement code '{}'", conditionValue, code);
+            return ProgressView.none();
+        }
+    }
+
+    private record ProgressView(Integer current, Integer target) {
+        static ProgressView none() {
+            return new ProgressView(null, null);
+        }
+
+        static ProgressView of(int current, int target) {
+            // 달성 완료분은 target 으로 캡 (예: 12/10 -> 10/10)
+            return new ProgressView(Math.min(current, target), target);
+        }
     }
 
     /**

--- a/apps/backend/src/main/java/com/sos/backend/domain/stat/controller/StatsController.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/stat/controller/StatsController.java
@@ -1,11 +1,13 @@
 package com.sos.backend.domain.stat.controller;
 
+import com.sos.backend.domain.stat.dto.PhishingBreakdownResponse;
 import com.sos.backend.domain.stat.dto.UserStatResponse;
 import com.sos.backend.domain.stat.service.StatsService;
 import com.sos.backend.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,5 +30,14 @@ public class StatsController {
         @AuthenticationPrincipal Long userId
     ) {
         return ApiResponse.success(statsService.getMyStats(userId));
+    }
+
+    @GetMapping("/phishing-breakdown")
+    @Operation(summary = "사기 유형별 강약점 조회",
+        description = "play_logs 를 phishing_type 으로 그룹한 유형별 플레이수·안전 결말수·평균 위험선택·평균 점수. 플레이 기록이 없으면 빈 목록.")
+    public ApiResponse<List<PhishingBreakdownResponse>> getPhishingBreakdown(
+        @AuthenticationPrincipal Long userId
+    ) {
+        return ApiResponse.success(statsService.getPhishingBreakdown(userId));
     }
 }

--- a/apps/backend/src/main/java/com/sos/backend/domain/stat/dto/PhishingBreakdownResponse.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/stat/dto/PhishingBreakdownResponse.java
@@ -1,0 +1,32 @@
+package com.sos.backend.domain.stat.dto;
+
+import com.sos.backend.global.internal.dto.PhishingBreakdownInternalResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "사기 유형별 강약점 집계 항목")
+public record PhishingBreakdownResponse(
+    @Schema(description = "사기 유형", example = "smishing")
+    String phishingType,
+
+    @Schema(description = "해당 유형 완료 플레이 수", example = "5")
+    int playCount,
+
+    @Schema(description = "안전(good) 결말 수", example = "3")
+    int goodCount,
+
+    @Schema(description = "판당 평균 위험 선택 수", example = "1.4")
+    double avgDangerous,
+
+    @Schema(description = "평균 점수", example = "62.5")
+    double avgScore
+) {
+    public static PhishingBreakdownResponse from(PhishingBreakdownInternalResponse internal) {
+        return new PhishingBreakdownResponse(
+            internal.phishingType(),
+            internal.playCount(),
+            internal.goodCount(),
+            internal.avgDangerous(),
+            internal.avgScore()
+        );
+    }
+}

--- a/apps/backend/src/main/java/com/sos/backend/domain/stat/service/StatsService.java
+++ b/apps/backend/src/main/java/com/sos/backend/domain/stat/service/StatsService.java
@@ -1,7 +1,10 @@
 package com.sos.backend.domain.stat.service;
 
+import com.sos.backend.domain.stat.dto.PhishingBreakdownResponse;
 import com.sos.backend.domain.stat.dto.UserStatResponse;
 import com.sos.backend.domain.user.repository.UserStatRepository;
+import com.sos.backend.global.internal.GameEngineClient;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * 사용자 통계 조회(읽기 전용). 통계 누적/쓰기는 StatsSyncService 가 담당한다.
  * 통계 행이 없는(게임 미완료) 사용자는 행을 생성하지 않고 0 통계를 반환한다.
+ * 사기 유형별 집계는 play_logs 를 보유한 game-engine 으로 프록시한다(history 패턴).
  */
 @Service
 @RequiredArgsConstructor
@@ -16,10 +20,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class StatsService {
 
     private final UserStatRepository userStatRepository;
+    private final GameEngineClient gameEngineClient;
 
     public UserStatResponse getMyStats(Long userId) {
         return userStatRepository.findByUserId(userId)
             .map(UserStatResponse::from)
             .orElseGet(UserStatResponse::empty);
+    }
+
+    public List<PhishingBreakdownResponse> getPhishingBreakdown(Long userId) {
+        return gameEngineClient.getPhishingBreakdown(userId).stream()
+            .map(PhishingBreakdownResponse::from)
+            .toList();
     }
 }

--- a/apps/backend/src/main/java/com/sos/backend/global/internal/GameEngineClient.java
+++ b/apps/backend/src/main/java/com/sos/backend/global/internal/GameEngineClient.java
@@ -2,6 +2,7 @@ package com.sos.backend.global.internal;
 
 import com.sos.backend.global.common.exception.CustomException;
 import com.sos.backend.global.common.exception.ErrorCode;
+import com.sos.backend.global.internal.dto.PhishingBreakdownInternalResponse;
 import com.sos.backend.global.internal.dto.PlayLogDetailInternalResponse;
 import com.sos.backend.global.internal.dto.ScenarioProgressInternalResponse;
 import com.sos.backend.global.internal.dto.PlayLogSummaryInternalResponse;
@@ -58,6 +59,19 @@ public class GameEngineClient {
         } catch (RestClientException e) {
             log.error("Game Engine internal play-logs call failed: userId={}, scenarioId={}",
                 userId, scenarioId, e);
+            throw new CustomException(ErrorCode.INTERNAL_API_ERROR);
+        }
+    }
+
+    public List<PhishingBreakdownInternalResponse> getPhishingBreakdown(long userId) {
+        try {
+            List<PhishingBreakdownInternalResponse> result = restClient.get()
+                .uri("/api/internal/stats/phishing-breakdown/{userId}", userId)
+                .retrieve()
+                .body(new ParameterizedTypeReference<List<PhishingBreakdownInternalResponse>>() {});
+            return result != null ? result : List.of();
+        } catch (RestClientException e) {
+            log.error("Game Engine internal phishing-breakdown call failed: userId={}", userId, e);
             throw new CustomException(ErrorCode.INTERNAL_API_ERROR);
         }
     }

--- a/apps/backend/src/main/java/com/sos/backend/global/internal/dto/PhishingBreakdownInternalResponse.java
+++ b/apps/backend/src/main/java/com/sos/backend/global/internal/dto/PhishingBreakdownInternalResponse.java
@@ -1,0 +1,18 @@
+package com.sos.backend.global.internal.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+/**
+ * game-engine GET /api/internal/stats/phishing-breakdown/{userId} 응답 항목.
+ * game-engine 은 snake_case 로 직렬화 → SnakeCaseStrategy 로 매핑.
+ */
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record PhishingBreakdownInternalResponse(
+    String phishingType,
+    int playCount,
+    int goodCount,
+    double avgDangerous,
+    double avgScore
+) {
+}

--- a/apps/backend/src/test/java/com/sos/backend/domain/achievement/service/AchievementServiceTest.java
+++ b/apps/backend/src/test/java/com/sos/backend/domain/achievement/service/AchievementServiceTest.java
@@ -1,0 +1,106 @@
+package com.sos.backend.domain.achievement.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+import com.sos.backend.domain.achievement.dto.AchievementResponse;
+import com.sos.backend.domain.achievement.entity.Achievement;
+import com.sos.backend.domain.achievement.entity.UserAchievement;
+import com.sos.backend.domain.achievement.repository.AchievementRepository;
+import com.sos.backend.domain.achievement.repository.UserAchievementRepository;
+import com.sos.backend.domain.user.entity.UserStat;
+import com.sos.backend.domain.user.repository.UserStatRepository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AchievementServiceTest {
+
+    @Mock
+    private AchievementRepository achievementRepository;
+
+    @Mock
+    private UserAchievementRepository userAchievementRepository;
+
+    @Mock
+    private UserStatRepository userStatRepository;
+
+    @InjectMocks
+    private AchievementService achievementService;
+
+    private static Achievement achievement(long id, String code, String conditionValue) {
+        return Achievement.builder()
+            .achievementId(id)
+            .code(code)
+            .title(code)
+            .description("d")
+            .iconUrl(null)
+            .conditionValue(conditionValue)
+            .build();
+    }
+
+    private Map<String, AchievementResponse> run(UserStat stat) {
+        given(userAchievementRepository.findByUserIdWithAchievement(anyLong()))
+            .willReturn(List.<UserAchievement>of());
+        given(userStatRepository.findByUserId(anyLong())).willReturn(Optional.ofNullable(stat));
+        given(achievementRepository.findAll()).willReturn(List.of(
+            achievement(1, "FIRST_CLEAR", "1"),
+            achievement(2, "PLAY_10", "10"),
+            achievement(3, "PLAY_30", "30"),
+            achievement(4, "GOOD_ENDING_5", "5"),
+            achievement(5, "FLAWLESS", "0"),
+            achievement(6, "FULL_COLLECTION", "1.0")
+        ));
+        return achievementService.getMyAchievements(1001L).stream()
+            .collect(Collectors.toMap(AchievementResponse::code, r -> r));
+    }
+
+    @Test
+    void cumulativeAchievementsExposeProgressCappedAtTarget() {
+        UserStat stat = UserStat.builder().completePlays(12).goodEndings(3).build();
+
+        Map<String, AchievementResponse> byCode = run(stat);
+
+        // completePlays(12) 기반 — 달성 완료분은 target 으로 캡
+        assertThat(byCode.get("FIRST_CLEAR").progressCurrent()).isEqualTo(1); // min(12, 1)
+        assertThat(byCode.get("FIRST_CLEAR").progressTarget()).isEqualTo(1);
+        assertThat(byCode.get("PLAY_10").progressCurrent()).isEqualTo(10); // min(12, 10) 캡
+        assertThat(byCode.get("PLAY_10").progressTarget()).isEqualTo(10);
+        assertThat(byCode.get("PLAY_30").progressCurrent()).isEqualTo(12);
+        assertThat(byCode.get("PLAY_30").progressTarget()).isEqualTo(30);
+        // goodEndings(3) 기반
+        assertThat(byCode.get("GOOD_ENDING_5").progressCurrent()).isEqualTo(3);
+        assertThat(byCode.get("GOOD_ENDING_5").progressTarget()).isEqualTo(5);
+    }
+
+    @Test
+    void nonCumulativeAchievementsHaveNullProgress() {
+        Map<String, AchievementResponse> byCode =
+            run(UserStat.builder().completePlays(5).goodEndings(5).build());
+
+        // per-play(FLAWLESS) / per-scenario(FULL_COLLECTION) 은 누적 N/M 불가 → null
+        assertThat(byCode.get("FLAWLESS").progressCurrent()).isNull();
+        assertThat(byCode.get("FLAWLESS").progressTarget()).isNull();
+        assertThat(byCode.get("FULL_COLLECTION").progressCurrent()).isNull();
+        assertThat(byCode.get("FULL_COLLECTION").progressTarget()).isNull();
+    }
+
+    @Test
+    void missingUserStatYieldsZeroCurrent() {
+        Map<String, AchievementResponse> byCode = run(null);
+
+        assertThat(byCode.get("PLAY_10").progressCurrent()).isEqualTo(0);
+        assertThat(byCode.get("PLAY_10").progressTarget()).isEqualTo(10);
+        assertThat(byCode.get("GOOD_ENDING_5").progressCurrent()).isEqualTo(0);
+        assertThat(byCode.get("GOOD_ENDING_5").progressTarget()).isEqualTo(5);
+    }
+}

--- a/apps/backend/src/test/java/com/sos/backend/domain/stat/service/StatsServiceTest.java
+++ b/apps/backend/src/test/java/com/sos/backend/domain/stat/service/StatsServiceTest.java
@@ -1,0 +1,57 @@
+package com.sos.backend.domain.stat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+import com.sos.backend.domain.stat.dto.PhishingBreakdownResponse;
+import com.sos.backend.domain.user.repository.UserStatRepository;
+import com.sos.backend.global.internal.GameEngineClient;
+import com.sos.backend.global.internal.dto.PhishingBreakdownInternalResponse;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class StatsServiceTest {
+
+    @Mock
+    private UserStatRepository userStatRepository;
+
+    @Mock
+    private GameEngineClient gameEngineClient;
+
+    @InjectMocks
+    private StatsService statsService;
+
+    @Test
+    void getPhishingBreakdown_mapsInternalToPublic() {
+        long userId = 1001L;
+        given(gameEngineClient.getPhishingBreakdown(userId)).willReturn(List.of(
+            new PhishingBreakdownInternalResponse("smishing", 5, 3, 1.4, 62.5),
+            new PhishingBreakdownInternalResponse("voice_phishing", 2, 0, 3.0, 28.0)
+        ));
+
+        List<PhishingBreakdownResponse> result = statsService.getPhishingBreakdown(userId);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).phishingType()).isEqualTo("smishing");
+        assertThat(result.get(0).playCount()).isEqualTo(5);
+        assertThat(result.get(0).goodCount()).isEqualTo(3);
+        assertThat(result.get(0).avgDangerous()).isEqualTo(1.4);
+        assertThat(result.get(0).avgScore()).isEqualTo(62.5);
+        assertThat(result.get(1).phishingType()).isEqualTo("voice_phishing");
+        assertThat(result.get(1).goodCount()).isEqualTo(0);
+    }
+
+    @Test
+    void getPhishingBreakdown_returnsEmptyWhenNoPlays() {
+        given(gameEngineClient.getPhishingBreakdown(anyLong())).willReturn(List.of());
+
+        assertThat(statsService.getPhishingBreakdown(1001L)).isEmpty();
+    }
+}

--- a/apps/frontend/src/features/achievement/__tests__/AchievementsTab.order.test.tsx
+++ b/apps/frontend/src/features/achievement/__tests__/AchievementsTab.order.test.tsx
@@ -11,7 +11,12 @@ vi.mock('../hooks', () => ({ useAchievements: vi.fn() }))
 
 const mockedAchievements = useAchievements as unknown as Mock
 
-const make = (id: number, code: string, title: string): AchievementSummary => ({
+const make = (
+  id: number,
+  code: string,
+  title: string,
+  progress?: { current: number | null; target: number | null },
+): AchievementSummary => ({
   id,
   code,
   title,
@@ -19,6 +24,8 @@ const make = (id: number, code: string, title: string): AchievementSummary => ({
   iconUrl: null,
   isAchieved: false,
   achievedAt: null,
+  progressCurrent: progress?.current ?? null,
+  progressTarget: progress?.target ?? null,
 })
 
 beforeEach(() => mockedAchievements.mockReset())
@@ -56,5 +63,33 @@ describe('AchievementsTab card ordering', () => {
       '안전 길잡이',
       '무결점 판별',
     ])
+  })
+})
+
+describe('AchievementsTab progress bar', () => {
+  it('renders a progressbar with N/M for cumulative achievements and omits it for null progress', () => {
+    const achievements = [
+      make(1, 'PLAY_10', '반복 숙련가', { current: 3, target: 10 }),
+      make(2, 'FLAWLESS', '무결점 판별', { current: null, target: null }),
+    ]
+    mockedAchievements.mockReturnValue({
+      isPending: false,
+      isError: false,
+      data: { achievements, achievedCount: 0, totalCount: 2 },
+    })
+
+    const { Wrapper } = createWrapper()
+    render(<AchievementsTab focusAchievementId={null} onFocusHandled={vi.fn()} />, {
+      wrapper: Wrapper,
+    })
+
+    // 카드 진행 바는 "진행 N/M" 라벨(상단 전체 진행도 바와 구분). 누적형 1개만 존재.
+    const cardBars = screen
+      .getAllByRole('progressbar')
+      .filter((bar) => bar.getAttribute('aria-label')?.startsWith('진행 '))
+    expect(cardBars).toHaveLength(1)
+    expect(cardBars[0]).toHaveAttribute('aria-valuenow', '3')
+    expect(cardBars[0]).toHaveAttribute('aria-valuemax', '10')
+    expect(screen.getByText('3/10')).toBeInTheDocument()
   })
 })

--- a/apps/frontend/src/features/achievement/__tests__/api.test.ts
+++ b/apps/frontend/src/features/achievement/__tests__/api.test.ts
@@ -25,6 +25,8 @@ describe('achievementApi.getAchievements', () => {
             icon_url: 'https://x/y.png',
             unlocked: true,
             achieved_at: '2026-05-01T10:00:00',
+            progress_current: 1,
+            progress_target: 1,
           },
           {
             achievement_id: 2,
@@ -34,6 +36,7 @@ describe('achievementApi.getAchievements', () => {
             icon_url: null,
             unlocked: false,
             achieved_at: null,
+            // 누적 N/M 불가 업적은 progress 필드가 내려오지 않음 → null 정규화
           },
         ],
       },
@@ -52,6 +55,11 @@ describe('achievementApi.getAchievements', () => {
       iconUrl: 'https://x/y.png',
       isAchieved: true,
       achievedAt: '2026-05-01T10:00:00',
+      progressCurrent: 1,
+      progressTarget: 1,
     })
+    // progress 필드가 누락된 항목은 null 로 정규화된다.
+    expect(result.achievements[1].progressCurrent).toBeNull()
+    expect(result.achievements[1].progressTarget).toBeNull()
   })
 })

--- a/apps/frontend/src/features/achievement/api.ts
+++ b/apps/frontend/src/features/achievement/api.ts
@@ -19,6 +19,8 @@ type AchievementWire = {
   icon_url: string | null
   unlocked: boolean
   achieved_at: string | null
+  progress_current?: number | null
+  progress_target?: number | null
 }
 
 const toAchievementSummary = (wire: AchievementWire): AchievementSummary => ({
@@ -29,6 +31,8 @@ const toAchievementSummary = (wire: AchievementWire): AchievementSummary => ({
   iconUrl: wire.icon_url,
   isAchieved: wire.unlocked,
   achievedAt: wire.achieved_at,
+  progressCurrent: wire.progress_current ?? null,
+  progressTarget: wire.progress_target ?? null,
 })
 
 export const achievementApi = {

--- a/apps/frontend/src/features/achievement/components/AchievementsTab.tsx
+++ b/apps/frontend/src/features/achievement/components/AchievementsTab.tsx
@@ -206,7 +206,33 @@ export function AchievementsTab({ focusAchievementId, onFocusHandled }: Achievem
                   ? `달성일 ${formatAchievedDate(achievement.achievedAt)}`
                   : '잠금'}
               </p>
-              {/* TODO(BE): 업적별 진행 수치 API 추가 시 카드 하단에 실제 진행률 바 표시 */}
+              {/* 누적형 업적만 진행 바 표시. per-play/per-scenario 업적은 progressTarget 이 null 이라 생략. */}
+              {achievement.progressTarget != null &&
+              achievement.progressTarget > 0 &&
+              achievement.progressCurrent != null ? (
+                <div className="mt-3 w-full">
+                  <div
+                    role="progressbar"
+                    aria-valuenow={achievement.progressCurrent}
+                    aria-valuemin={0}
+                    aria-valuemax={achievement.progressTarget}
+                    aria-label={`진행 ${achievement.progressCurrent}/${achievement.progressTarget}`}
+                    className="h-1.5 w-full overflow-hidden rounded-full bg-slate-800"
+                  >
+                    <div
+                      className="h-full rounded-full bg-emerald-400 transition-[width]"
+                      style={{
+                        width: `${Math.round(
+                          (achievement.progressCurrent / achievement.progressTarget) * 100,
+                        )}%`,
+                      }}
+                    />
+                  </div>
+                  <p className="mt-1 text-xs tabular-nums text-sos-faint">
+                    {achievement.progressCurrent}/{achievement.progressTarget}
+                  </p>
+                </div>
+              ) : null}
             </button>
           ))}
         </div>

--- a/apps/frontend/src/features/achievement/types.ts
+++ b/apps/frontend/src/features/achievement/types.ts
@@ -6,6 +6,9 @@ export type AchievementSummary = {
   iconUrl: string | null
   isAchieved: boolean
   achievedAt: string | null
+  // 누적 진행 수치. 누적 N/M 이 불가한 업적(FLAWLESS·FULL_COLLECTION)은 null → 진행 바 미표시.
+  progressCurrent: number | null
+  progressTarget: number | null
 }
 
 export type AchievementListResponse = {

--- a/apps/frontend/src/features/game-session/pages/LobbyPage.tsx
+++ b/apps/frontend/src/features/game-session/pages/LobbyPage.tsx
@@ -9,6 +9,7 @@ import {
   useScenarios,
 } from '@/features/game/hooks'
 import { getRecommendedScenarios } from '@/features/game/recommendation'
+import { filterScenarios } from '@/features/game/search'
 import { useGameStore } from '@/features/game/store'
 import type { Difficulty, ScenarioSummary } from '@/features/game/types'
 import { useUserProfile } from '@/features/user/hooks'
@@ -91,6 +92,7 @@ export function LobbyPage() {
   )
   const [resumePrompt, setResumePrompt] = useState<ResumePromptState | null>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [searchQuery, setSearchQuery] = useState('')
   const userName = profileQuery.data?.name?.trim() || '회원'
 
   useEffect(() => {
@@ -213,6 +215,11 @@ export function LobbyPage() {
   const recommendedScenarios = useMemo(
     () => getRecommendedScenarios(profileQuery.data, scenariosQuery.data, 2),
     [profileQuery.data, scenariosQuery.data],
+  )
+
+  const filteredScenarios = useMemo(
+    () => filterScenarios(scenariosQuery.data, searchQuery),
+    [scenariosQuery.data, searchQuery],
   )
 
   return (
@@ -338,17 +345,49 @@ export function LobbyPage() {
 
       {scenariosQuery.data && scenariosQuery.data.length > 0 ? (
         <section className="space-y-4">
-          <h2 className="text-xl font-semibold text-sos-strong">전체 시나리오</h2>
-          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-            {scenariosQuery.data.map((scenario) => (
-              <ScenarioCard
-                key={scenario.scenario_id}
-                scenario={scenario}
-                onStart={handleStart}
-                isBusy={isStartingSession}
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <h2 className="text-xl font-semibold text-sos-strong">전체 시나리오</h2>
+            <div className="relative sm:w-80">
+              <svg
+                viewBox="0 0 20 20"
+                aria-hidden="true"
+                className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-sos-faint"
+              >
+                <path
+                  d="M9 3a6 6 0 104.47 10.03l3.25 3.25 1.06-1.06-3.25-3.25A6 6 0 009 3zm0 1.5a4.5 4.5 0 110 9 4.5 4.5 0 010-9z"
+                  fill="currentColor"
+                />
+              </svg>
+              <input
+                type="search"
+                value={searchQuery}
+                onChange={(event) => setSearchQuery(event.target.value)}
+                placeholder="제목·사기 유형으로 검색"
+                aria-label="시나리오 검색"
+                className="w-full rounded-md border border-sos-line bg-sos-surface-1 py-2 pl-9 pr-3 text-sm text-sos-strong placeholder:text-sos-faint focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-200"
               />
-            ))}
+            </div>
           </div>
+
+          {filteredScenarios.length > 0 ? (
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {filteredScenarios.map((scenario) => (
+                <ScenarioCard
+                  key={scenario.scenario_id}
+                  scenario={scenario}
+                  onStart={handleStart}
+                  isBusy={isStartingSession}
+                />
+              ))}
+            </div>
+          ) : (
+            <p
+              role="status"
+              className="rounded-xl border border-sos-line bg-sos-surface-1 p-6 text-center text-sm text-sos-body"
+            >
+              ‘{searchQuery.trim()}’에 대한 검색 결과가 없어요.
+            </p>
+          )}
         </section>
       ) : null}
 

--- a/apps/frontend/src/features/game/__tests__/search.test.ts
+++ b/apps/frontend/src/features/game/__tests__/search.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import { filterScenarios } from '../search'
+import type { ScenarioSummary } from '../types'
+
+const make = (
+  scenario_id: string,
+  title: string,
+  phishing_type: string,
+  description = '설명',
+): ScenarioSummary => ({
+  scenario_id,
+  title,
+  description,
+  phishing_type,
+  difficulty: 'easy',
+  total_endings: 1,
+  total_good_endings: 1,
+  total_bad_endings: 0,
+  tags: [],
+})
+
+const scenarios = [
+  make('s1', '택배 사칭 문자', '스미싱'),
+  make('s2', '검찰 사칭 전화', '보이스피싱'),
+  make('s3', '로맨스 스캠', '연애 빙자 사기', '소개팅 앱에서 만난 상대'),
+]
+
+describe('filterScenarios', () => {
+  it('returns the full list for an empty or whitespace query', () => {
+    expect(filterScenarios(scenarios, '')).toHaveLength(3)
+    expect(filterScenarios(scenarios, '   ')).toHaveLength(3)
+  })
+
+  it('matches by title (case-insensitive)', () => {
+    expect(filterScenarios(scenarios, '택배').map((s) => s.scenario_id)).toEqual(['s1'])
+  })
+
+  it('matches by phishing type', () => {
+    expect(filterScenarios(scenarios, '보이스피싱').map((s) => s.scenario_id)).toEqual(['s2'])
+  })
+
+  it('matches by description', () => {
+    expect(filterScenarios(scenarios, '소개팅').map((s) => s.scenario_id)).toEqual(['s3'])
+  })
+
+  it('returns an empty array when nothing matches', () => {
+    expect(filterScenarios(scenarios, '존재하지않는검색어')).toEqual([])
+  })
+
+  it('handles undefined input', () => {
+    expect(filterScenarios(undefined, '택배')).toEqual([])
+  })
+})

--- a/apps/frontend/src/features/game/search.ts
+++ b/apps/frontend/src/features/game/search.ts
@@ -1,0 +1,21 @@
+import type { ScenarioSummary } from '@/features/game/types'
+
+/**
+ * 로비 시나리오 검색. 제목·사기 유형·설명을 대소문자 무시 부분일치로 필터링한다.
+ * 공백 쿼리는 전체 목록을 그대로 반환한다(클라이언트 측, 로드된 목록 대상).
+ */
+export const filterScenarios = (
+  scenarios: ScenarioSummary[] | undefined,
+  query: string,
+): ScenarioSummary[] => {
+  const list = scenarios ?? []
+  const q = query.trim().toLowerCase()
+  if (!q) return list
+
+  return list.filter((scenario) =>
+    [scenario.title, scenario.phishing_type, scenario.description]
+      .join('\n')
+      .toLowerCase()
+      .includes(q),
+  )
+}

--- a/apps/frontend/src/features/game/types.ts
+++ b/apps/frontend/src/features/game/types.ts
@@ -111,6 +111,8 @@ export interface ScenarioSummary {
   total_endings: number
   total_good_endings: number
   total_bad_endings: number
+  // 결말 유형(ending_category) 수. 구버전 응답 호환을 위해 옵셔널(합산 시 ?? 0).
+  total_categories?: number
   tags: string[]
 }
 

--- a/apps/frontend/src/features/notification/__tests__/hooks.test.tsx
+++ b/apps/frontend/src/features/notification/__tests__/hooks.test.tsx
@@ -13,23 +13,28 @@ const makeClient = () =>
     },
   })
 
+import { useAuthStore } from '@/features/auth/store'
+
 import { notificationApi } from '../api'
 import {
   useDeleteAllNotifications,
   useDeleteNotification,
   useMarkNotificationRead,
+  useNotifications,
 } from '../hooks'
 import { notificationKeys } from '../queryKeys'
 import type { NotificationListResponse } from '../types'
 
 vi.mock('../api', () => ({
   notificationApi: {
+    getNotifications: vi.fn(),
     markNotificationRead: vi.fn(),
     deleteNotification: vi.fn(),
     deleteAllNotifications: vi.fn(),
   },
 }))
 
+const mockedGet = notificationApi.getNotifications as unknown as Mock
 const mockedMarkRead = notificationApi.markNotificationRead as unknown as Mock
 const mockedDelete = notificationApi.deleteNotification as unknown as Mock
 const mockedDeleteAll = notificationApi.deleteAllNotifications as unknown as Mock
@@ -43,9 +48,43 @@ const seedList = (): NotificationListResponse => ({
 })
 
 beforeEach(() => {
+  mockedGet.mockReset()
   mockedMarkRead.mockReset()
   mockedDelete.mockReset()
   mockedDeleteAll.mockReset()
+  useAuthStore.setState({ accessToken: null })
+})
+
+describe('useNotifications polling', () => {
+  it('does not fetch while unauthenticated (enabled gated by access token)', () => {
+    const { Wrapper } = createWrapper({ queryClient: makeClient() })
+
+    renderHook(() => useNotifications(), { wrapper: Wrapper })
+
+    expect(mockedGet).not.toHaveBeenCalled()
+  })
+
+  it('refetches on a 60s interval when authenticated', async () => {
+    vi.useFakeTimers()
+    try {
+      useAuthStore.setState({ accessToken: 'token' })
+      mockedGet.mockResolvedValue(seedList())
+      const { Wrapper } = createWrapper({ queryClient: makeClient() })
+
+      renderHook(() => useNotifications(), { wrapper: Wrapper })
+
+      await vi.advanceTimersByTimeAsync(0)
+      expect(mockedGet).toHaveBeenCalledTimes(1)
+
+      await vi.advanceTimersByTimeAsync(60_000)
+      expect(mockedGet).toHaveBeenCalledTimes(2)
+
+      await vi.advanceTimersByTimeAsync(60_000)
+      expect(mockedGet).toHaveBeenCalledTimes(3)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })
 
 describe('useMarkNotificationRead optimistic update', () => {

--- a/apps/frontend/src/features/notification/hooks.ts
+++ b/apps/frontend/src/features/notification/hooks.ts
@@ -13,6 +13,9 @@ export const useNotifications = () => {
     queryKey: notificationKeys.list(),
     queryFn: notificationApi.getNotifications,
     enabled: Boolean(accessToken),
+    // 벨 뱃지를 준실시간으로 유지하기 위한 폴링. 숨겨진 탭에서는 폴링하지 않는다.
+    refetchInterval: 60_000,
+    refetchIntervalInBackground: false,
   })
 }
 

--- a/apps/frontend/src/features/stats/__tests__/CollectionMapSection.test.tsx
+++ b/apps/frontend/src/features/stats/__tests__/CollectionMapSection.test.tsx
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import { createWrapper } from '@/test/test-utils'
+import { useScenarios } from '@/features/game/hooks'
+import { useScenarioProgress } from '@/features/history/hooks'
+
+import { CollectionMapSection } from '../components/CollectionMapSection'
+
+vi.mock('@/features/game/hooks', () => ({ useScenarios: vi.fn() }))
+vi.mock('@/features/history/hooks', () => ({ useScenarioProgress: vi.fn() }))
+
+const mockedProgress = useScenarioProgress as unknown as Mock
+const mockedScenarios = useScenarios as unknown as Mock
+
+const renderSection = () => {
+  const { Wrapper } = createWrapper()
+  return render(<CollectionMapSection />, { wrapper: Wrapper })
+}
+
+beforeEach(() => {
+  mockedProgress.mockReset()
+  mockedScenarios.mockReset()
+})
+
+describe('CollectionMapSection', () => {
+  it('renders a donut over the whole service: discovered / all-scenarios categories', () => {
+    // 발견: sc1 2개 + sc2 3개 = 5
+    mockedProgress.mockReturnValue({
+      isPending: false,
+      isError: false,
+      data: [
+        { scenarioId: 'sc1', completionRate: 0.4, discoveredCategoryCount: 2, totalCategories: 5, lastPlayedAt: 't' },
+        { scenarioId: 'sc2', completionRate: 1, discoveredCategoryCount: 3, totalCategories: 3, lastPlayedAt: 't' },
+      ],
+    })
+    // 전체 분모: 미플레이 sc3 포함 10+10+10 = 30
+    mockedScenarios.mockReturnValue({
+      data: [
+        { scenario_id: 'sc1', total_categories: 10 },
+        { scenario_id: 'sc2', total_categories: 10 },
+        { scenario_id: 'sc3', total_categories: 10 },
+      ],
+    })
+
+    renderSection()
+
+    // 도넛 중앙: 5/30, round(5/30*100)=17%
+    expect(screen.getByText('5/30')).toBeInTheDocument()
+    expect(screen.getByText('17%')).toBeInTheDocument()
+    expect(
+      screen.getByText('서비스 전체 결말 유형 30개 중 5개를 발견했어요.'),
+    ).toBeInTheDocument()
+  })
+
+  it('renders nothing when no scenario exposes categories (denominator 0)', () => {
+    mockedProgress.mockReturnValue({ isPending: false, isError: false, data: [] })
+    mockedScenarios.mockReturnValue({ data: [{ scenario_id: 'sc1' }] })
+    const { container } = renderSection()
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/apps/frontend/src/features/stats/__tests__/PhishingBreakdownSection.test.tsx
+++ b/apps/frontend/src/features/stats/__tests__/PhishingBreakdownSection.test.tsx
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import { createWrapper } from '@/test/test-utils'
+
+import { usePhishingBreakdown } from '../hooks'
+import { PhishingBreakdownSection } from '../components/PhishingBreakdownSection'
+
+vi.mock('../hooks', () => ({ usePhishingBreakdown: vi.fn() }))
+
+const mockedBreakdown = usePhishingBreakdown as unknown as Mock
+
+const renderSection = () => {
+  const { Wrapper } = createWrapper()
+  return render(<PhishingBreakdownSection />, { wrapper: Wrapper })
+}
+
+beforeEach(() => mockedBreakdown.mockReset())
+
+describe('PhishingBreakdownSection', () => {
+  it('renders a safe-rate bar per phishing type with known slug labels mapped', () => {
+    mockedBreakdown.mockReturnValue({
+      isPending: false,
+      isError: false,
+      data: [
+        { phishingType: 'smishing', playCount: 4, goodCount: 3, avgDangerous: 1.0, avgScore: 70 },
+        {
+          phishingType: '정부지원금 안내를 사칭한 스미싱',
+          playCount: 2,
+          goodCount: 0,
+          avgDangerous: 3.5,
+          avgScore: 30,
+        },
+      ],
+    })
+
+    renderSection()
+
+    // 알려진 슬러그는 한국어로, 자유 문자열은 원문 그대로
+    expect(screen.getByText('스미싱')).toBeInTheDocument()
+    expect(screen.getByText('정부지원금 안내를 사칭한 스미싱')).toBeInTheDocument()
+
+    // 안전율 바: smishing = round(3/4*100) = 75
+    const smishingBar = screen.getByRole('progressbar', { name: '스미싱 안전 결말률' })
+    expect(smishingBar).toHaveAttribute('aria-valuenow', '75')
+    expect(screen.getByText('75% · 4판')).toBeInTheDocument()
+  })
+
+  it('sorts weakest (lowest safe-rate) types first', () => {
+    mockedBreakdown.mockReturnValue({
+      isPending: false,
+      isError: false,
+      data: [
+        { phishingType: 'smishing', playCount: 4, goodCount: 4, avgDangerous: 0, avgScore: 90 },
+        { phishingType: 'phishing', playCount: 2, goodCount: 0, avgDangerous: 4, avgScore: 20 },
+      ],
+    })
+
+    renderSection()
+
+    const bars = screen.getAllByRole('progressbar')
+    // 오름차순: phishing(0%) 먼저, smishing(100%) 다음
+    expect(bars[0]).toHaveAttribute('aria-label', '피싱 안전 결말률')
+    expect(bars[0]).toHaveAttribute('aria-valuenow', '0')
+    expect(bars[1]).toHaveAttribute('aria-valuenow', '100')
+  })
+
+  it('renders nothing when there is no play data', () => {
+    mockedBreakdown.mockReturnValue({ isPending: false, isError: false, data: [] })
+    const { container } = renderSection()
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders an error card with retry on error', () => {
+    mockedBreakdown.mockReturnValue({
+      isPending: false,
+      isError: true,
+      error: new Error('boom'),
+      refetch: vi.fn(),
+    })
+    renderSection()
+    expect(screen.getByRole('button', { name: '다시 시도' })).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/features/stats/__tests__/StatsTab.test.tsx
+++ b/apps/frontend/src/features/stats/__tests__/StatsTab.test.tsx
@@ -2,16 +2,20 @@ import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
 import { render, screen } from '@testing-library/react'
 
 import { createWrapper } from '@/test/test-utils'
-import { useAchievements } from '@/features/achievement/hooks'
+import { useScenarios } from '@/features/game/hooks'
+import { useScenarioProgress } from '@/features/history/hooks'
 
-import { useUserStats } from '../hooks'
+import { usePhishingBreakdown, useUserStats } from '../hooks'
 import { StatsTab } from '../components/StatsTab'
 
-vi.mock('../hooks', () => ({ useUserStats: vi.fn() }))
-vi.mock('@/features/achievement/hooks', () => ({ useAchievements: vi.fn() }))
+vi.mock('../hooks', () => ({ useUserStats: vi.fn(), usePhishingBreakdown: vi.fn() }))
+vi.mock('@/features/game/hooks', () => ({ useScenarios: vi.fn() }))
+vi.mock('@/features/history/hooks', () => ({ useScenarioProgress: vi.fn() }))
 
 const mockedStats = useUserStats as unknown as Mock
-const mockedAchievements = useAchievements as unknown as Mock
+const mockedBreakdown = usePhishingBreakdown as unknown as Mock
+const mockedScenarios = useScenarios as unknown as Mock
+const mockedProgress = useScenarioProgress as unknown as Mock
 
 const renderTab = () => {
   const { Wrapper } = createWrapper()
@@ -20,8 +24,10 @@ const renderTab = () => {
 
 beforeEach(() => {
   mockedStats.mockReset()
-  mockedAchievements.mockReset()
-  mockedAchievements.mockReturnValue({ data: undefined })
+  // 신규 섹션은 기본적으로 빈 데이터(→ null 렌더)로 둬서 상태 테스트에 영향 없게 한다.
+  mockedBreakdown.mockReturnValue({ isPending: false, isError: false, data: [] })
+  mockedProgress.mockReturnValue({ isPending: false, isError: false, data: [] })
+  mockedScenarios.mockReturnValue({ data: [] })
 })
 
 describe('StatsTab states', () => {
@@ -69,7 +75,6 @@ describe('StatsTab states', () => {
         bestScore: 95,
       },
     })
-    mockedAchievements.mockReturnValue({ data: { achievedCount: 3, totalCount: 6 } })
     renderTab()
 
     expect(screen.getByText('완료 플레이')).toBeInTheDocument()
@@ -80,5 +85,10 @@ describe('StatsTab states', () => {
     expect(screen.getByText('안전 73%')).toBeInTheDocument()
     const bar = screen.getByRole('progressbar', { name: '안전 결말 비율' })
     expect(bar).toHaveAttribute('aria-valuenow', '73')
+
+    // 완주율 게이지 = round(15/18*100)=83%, 판당 평균 위험선택 = (7/15)=0.5
+    expect(screen.getByRole('img', { name: '완주율 83%' })).toBeInTheDocument()
+    expect(screen.getByText('판당 평균 위험 선택')).toBeInTheDocument()
+    expect(screen.getByText('0.5')).toBeInTheDocument()
   })
 })

--- a/apps/frontend/src/features/stats/__tests__/api.test.ts
+++ b/apps/frontend/src/features/stats/__tests__/api.test.ts
@@ -31,3 +31,23 @@ describe('statsApi.getUserStats', () => {
     expect(result).toEqual(stats)
   })
 })
+
+describe('statsApi.getPhishingBreakdown', () => {
+  it('GET /users/me/stats/phishing-breakdown and unwraps the list', async () => {
+    const breakdown = [
+      { phishingType: 'smishing', playCount: 5, goodCount: 3, avgDangerous: 1.4, avgScore: 62.5 },
+    ]
+    mockedGet.mockResolvedValueOnce({ data: { data: breakdown } })
+
+    const result = await statsApi.getPhishingBreakdown()
+
+    expect(mockedGet).toHaveBeenCalledWith('/api/v1/users/me/stats/phishing-breakdown')
+    expect(result).toEqual(breakdown)
+  })
+
+  it('returns an empty array when payload is not a list', async () => {
+    mockedGet.mockResolvedValueOnce({ data: { data: null } })
+
+    expect(await statsApi.getPhishingBreakdown()).toEqual([])
+  })
+})

--- a/apps/frontend/src/features/stats/api.ts
+++ b/apps/frontend/src/features/stats/api.ts
@@ -2,7 +2,7 @@ import type { AxiosResponse } from 'axios'
 
 import { apiClient } from '@/shared/api/client'
 
-import type { UserStat } from './types'
+import type { PhishingBreakdown, UserStat } from './types'
 
 type ApiResponse<T> = {
   data: T
@@ -14,5 +14,12 @@ export const statsApi = {
   getUserStats: async () => {
     const response = await apiClient.get<ApiResponse<UserStat>>('/api/v1/users/me/stats')
     return unwrapData(response)
+  },
+  getPhishingBreakdown: async (): Promise<PhishingBreakdown[]> => {
+    const response = await apiClient.get<ApiResponse<PhishingBreakdown[]>>(
+      '/api/v1/users/me/stats/phishing-breakdown',
+    )
+    const payload = unwrapData(response)
+    return Array.isArray(payload) ? payload : []
   },
 }

--- a/apps/frontend/src/features/stats/components/CollectionMapSection.tsx
+++ b/apps/frontend/src/features/stats/components/CollectionMapSection.tsx
@@ -1,0 +1,47 @@
+import { useScenarios } from '@/features/game/hooks'
+import { useScenarioProgress } from '@/features/history/hooks'
+import { toApiError } from '@/shared/api/error'
+
+import { DonutChart } from './charts/DonutChart'
+
+export function CollectionMapSection() {
+  const progressQuery = useScenarioProgress()
+  const scenariosQuery = useScenarios()
+
+  if (progressQuery.isPending) {
+    return <div className="h-32 animate-pulse rounded-lg bg-slate-800" />
+  }
+
+  if (progressQuery.isError) {
+    return (
+      <div className="rounded-lg border border-red-300/25 bg-red-500/10 p-4">
+        <p className="text-sm text-red-100">{toApiError(progressQuery.error).message}</p>
+        <button
+          type="button"
+          onClick={() => void progressQuery.refetch()}
+          className="mt-3 rounded-lg bg-emerald-400 px-3 py-2 text-xs font-semibold text-slate-950 hover:bg-emerald-300"
+        >
+          다시 시도
+        </button>
+      </div>
+    )
+  }
+
+  // 분자: 플레이한 시나리오에서 발견한 결말 유형 수(미플레이는 progress 문서가 없어 0 기여).
+  const discovered = progressQuery.data.reduce((sum, p) => sum + p.discoveredCategoryCount, 0)
+  // 분모: 서비스 전체 시나리오의 결말 유형 수.
+  const total = (scenariosQuery.data ?? []).reduce((sum, s) => sum + (s.total_categories ?? 0), 0)
+
+  if (total === 0) {
+    return null
+  }
+
+  return (
+    <section className="flex flex-col items-center gap-2 rounded-lg border border-sos-line bg-sos-inset p-4">
+      <DonutChart value={discovered} max={total} label="결말 수집" />
+      <p className="text-center text-xs text-sos-faint">
+        서비스 전체 결말 유형 {total}개 중 {discovered}개를 발견했어요.
+      </p>
+    </section>
+  )
+}

--- a/apps/frontend/src/features/stats/components/PhishingBreakdownSection.tsx
+++ b/apps/frontend/src/features/stats/components/PhishingBreakdownSection.tsx
@@ -1,0 +1,121 @@
+import { toApiError } from '@/shared/api/error'
+
+import { usePhishingBreakdown } from '../hooks'
+import type { PhishingBreakdown } from '../types'
+
+// phishing_type 은 시드마다 자유 문자열(주로 한국어) 또는 영문 슬러그. 알려진 슬러그만
+// 한국어로 치환하고, 그 외(이미 한국어 라벨)는 원문 그대로 노출한다.
+const TYPE_LABEL: Record<string, string> = {
+  smishing: '스미싱',
+  voice_phishing: '보이스피싱',
+  vishing: '보이스피싱',
+  romance_scam: '로맨스 스캠',
+  investment_scam: '투자 사기',
+  pharming: '파밍',
+  phishing: '피싱',
+}
+
+const typeLabel = (phishingType: string) => TYPE_LABEL[phishingType] ?? phishingType
+
+// 안전 결말률이 낮을수록 더 연습이 필요한 유형 → 빨강, 높을수록 초록.
+const barColor = (rate: number) =>
+  rate < 40 ? 'bg-red-400' : rate < 70 ? 'bg-amber-400' : 'bg-emerald-400'
+
+type Row = PhishingBreakdown & { safeRate: number }
+
+function ChartRow({ item }: { item: Row }) {
+  return (
+    <li className="space-y-1">
+      <div className="flex items-baseline justify-between gap-3 text-xs">
+        <span className="min-w-0 flex-1 truncate font-medium text-sos-body">
+          {typeLabel(item.phishingType)}
+        </span>
+        <span className="shrink-0 tabular-nums text-sos-muted">
+          {item.safeRate}% · {item.playCount}판
+        </span>
+      </div>
+      <div
+        role="progressbar"
+        aria-label={`${typeLabel(item.phishingType)} 안전 결말률`}
+        aria-valuenow={item.safeRate}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        className="h-2.5 overflow-hidden rounded-full bg-slate-800"
+      >
+        <div
+          className={`h-full rounded-full ${barColor(item.safeRate)}`}
+          style={{ width: `${item.safeRate}%` }}
+        />
+      </div>
+      <p className="text-[11px] tabular-nums text-sos-faint">
+        판당 평균 위험 {item.avgDangerous.toFixed(1)} · 평균 점수 {item.avgScore.toFixed(0)}
+      </p>
+    </li>
+  )
+}
+
+export function PhishingBreakdownSection() {
+  const breakdownQuery = usePhishingBreakdown()
+
+  if (breakdownQuery.isPending) {
+    return <div className="h-28 animate-pulse rounded-lg bg-slate-800" />
+  }
+
+  if (breakdownQuery.isError) {
+    return (
+      <div className="rounded-lg border border-red-300/25 bg-red-500/10 p-4">
+        <p className="text-sm text-red-100">{toApiError(breakdownQuery.error).message}</p>
+        <button
+          type="button"
+          onClick={() => void breakdownQuery.refetch()}
+          className="mt-3 rounded-lg bg-emerald-400 px-3 py-2 text-xs font-semibold text-slate-950 hover:bg-emerald-300"
+        >
+          다시 시도
+        </button>
+      </div>
+    )
+  }
+
+  if (breakdownQuery.data.length === 0) {
+    return null
+  }
+
+  // 안전 결말률 오름차순 → 약한 유형(빨강)이 위로 와서 한눈에 들어온다.
+  const rows: Row[] = breakdownQuery.data
+    .map((item) => ({
+      ...item,
+      safeRate: item.playCount > 0 ? Math.round((item.goodCount / item.playCount) * 100) : 0,
+    }))
+    .sort((a, b) => a.safeRate - b.safeRate)
+
+  return (
+    <section className="space-y-3 rounded-lg border border-sos-line bg-sos-inset p-4">
+      <div>
+        <h3 className="text-sm font-semibold text-sos-strong">사기 유형별 강약점</h3>
+        <p className="mt-0.5 text-xs text-sos-faint">
+          안전 결말률이 낮은(빨강) 유형일수록 더 연습이 필요해요.
+        </p>
+      </div>
+
+      {/* 0/50/100 기준선 위에 막대를 그려 하나의 차트로 보이게 한다. */}
+      <div className="relative">
+        <div className="pointer-events-none absolute inset-0 flex justify-between">
+          <span className="w-px bg-slate-700/50" />
+          <span className="w-px bg-slate-700/50" />
+          <span className="w-px bg-slate-700/50" />
+        </div>
+        <ul className="relative space-y-3">
+          {rows.map((item) => (
+            <ChartRow key={item.phishingType} item={item} />
+          ))}
+        </ul>
+      </div>
+
+      <div className="flex justify-between text-[10px] tabular-nums text-sos-faint">
+        <span>0%</span>
+        <span>50%</span>
+        <span>100%</span>
+      </div>
+    </section>
+  )
+}

--- a/apps/frontend/src/features/stats/components/StatsTab.tsx
+++ b/apps/frontend/src/features/stats/components/StatsTab.tsx
@@ -1,9 +1,11 @@
 import { useNavigate } from 'react-router-dom'
 
-import { useAchievements } from '@/features/achievement/hooks'
 import { toApiError } from '@/shared/api/error'
 
 import { useUserStats } from '../hooks'
+import { CollectionMapSection } from './CollectionMapSection'
+import { PhishingBreakdownSection } from './PhishingBreakdownSection'
+import { RadialGauge } from './charts/RadialGauge'
 
 function StatsSkeleton() {
   return (
@@ -30,7 +32,6 @@ function MetricCard({ label, value }: { label: string; value: string }) {
 export function StatsTab() {
   const navigate = useNavigate()
   const statsQuery = useUserStats()
-  const achievementsQuery = useAchievements()
 
   if (statsQuery.isPending) {
     return <StatsSkeleton />
@@ -73,7 +74,16 @@ export function StatsTab() {
 
   const decided = stats.goodEndings + stats.badEndings
   const goodRate = decided > 0 ? Math.round((stats.goodEndings / decided) * 100) : 0
-  const achievements = achievementsQuery.data
+  const completionRate =
+    stats.totalPlays > 0 ? Math.round((stats.completePlays / stats.totalPlays) * 100) : 0
+  const avgDangerPerPlay =
+    stats.completePlays > 0 ? stats.totalDangerousChoices / stats.completePlays : 0
+  const coaching =
+    goodRate >= 70 && avgDangerPerPlay < 1
+      ? '훌륭해요! 위험 신호를 잘 피하고 있어요.'
+      : goodRate < 40
+        ? '주의 결말이 잦아요. 위험 선택을 줄여보세요.'
+        : '꾸준히 안전 결말을 늘려가고 있어요.'
 
   return (
     <div className="space-y-5">
@@ -82,6 +92,20 @@ export function StatsTab() {
         <MetricCard label="평균 점수" value={stats.avgScore.toFixed(1)} />
         <MetricCard label="최고 점수" value={String(stats.bestScore)} />
         <MetricCard label="누적 위험 선택" value={String(stats.totalDangerousChoices)} />
+      </div>
+
+      {/* 게이지(완주율)·도넛(결말 수집)을 상단 한 행으로 묶는다. */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <div className="flex items-center justify-around rounded-lg border border-sos-line bg-sos-inset p-4">
+          <RadialGauge value={completionRate} valueText={`${completionRate}%`} label="완주율" />
+          <div className="text-center">
+            <p className="text-2xl font-semibold tabular-nums text-sos-strong">
+              {avgDangerPerPlay.toFixed(1)}
+            </p>
+            <p className="mt-1 text-[13px] font-medium text-sos-muted">판당 평균 위험 선택</p>
+          </div>
+        </div>
+        <CollectionMapSection />
       </div>
 
       <div className="rounded-lg border border-sos-line bg-sos-inset p-4">
@@ -104,20 +128,10 @@ export function StatsTab() {
           <span className="tabular-nums text-emerald-200">안전 {stats.goodEndings}</span>
           <span className="tabular-nums text-red-200">주의 {stats.badEndings}</span>
         </div>
+        <p className="mt-3 border-t border-sos-line pt-3 text-xs text-sos-faint">{coaching}</p>
       </div>
 
-      {achievements ? (
-        <div className="rounded-lg border border-sos-line bg-sos-inset px-4 py-3">
-          <p className="text-[13px] font-medium text-sos-muted">업적 달성도</p>
-          <p className="mt-1 text-2xl font-semibold tabular-nums text-sos-strong">
-            {achievements.achievedCount}
-            <span className="text-base font-medium text-sos-muted">
-              {' '}
-              / {achievements.totalCount}
-            </span>
-          </p>
-        </div>
-      ) : null}
+      <PhishingBreakdownSection />
     </div>
   )
 }

--- a/apps/frontend/src/features/stats/components/charts/DonutChart.tsx
+++ b/apps/frontend/src/features/stats/components/charts/DonutChart.tsx
@@ -1,0 +1,62 @@
+type DonutChartProps = {
+  /** 발견 수(분자). */
+  value: number
+  /** 전체 수(분모). 0 이면 0% 로 그린다. */
+  max: number
+  /** 도넛 아래 라벨 (예: "결말 수집"). */
+  label: string
+}
+
+const SIZE = 120
+const STROKE = 14
+const RADIUS = (SIZE - STROKE) / 2
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS
+
+/** 발견/전체 수집률용 도넛 차트(손수 SVG, 의존성 없음). 중앙에 N/M + %. */
+export function DonutChart({ value, max, label }: DonutChartProps) {
+  const pct = max > 0 ? Math.max(0, Math.min(100, Math.round((value / max) * 100))) : 0
+  const dash = (pct / 100) * CIRCUMFERENCE
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <div className="relative" style={{ width: SIZE, height: SIZE }}>
+        <svg
+          viewBox={`0 0 ${SIZE} ${SIZE}`}
+          width={SIZE}
+          height={SIZE}
+          role="img"
+          aria-label={`${label} ${value}/${max} (${pct}%)`}
+        >
+          <circle
+            cx={SIZE / 2}
+            cy={SIZE / 2}
+            r={RADIUS}
+            fill="none"
+            strokeWidth={STROKE}
+            className="text-slate-800"
+            stroke="currentColor"
+          />
+          <circle
+            cx={SIZE / 2}
+            cy={SIZE / 2}
+            r={RADIUS}
+            fill="none"
+            strokeWidth={STROKE}
+            strokeLinecap="round"
+            strokeDasharray={`${dash} ${CIRCUMFERENCE - dash}`}
+            transform={`rotate(-90 ${SIZE / 2} ${SIZE / 2})`}
+            className="text-emerald-400 transition-[stroke-dasharray]"
+            stroke="currentColor"
+          />
+        </svg>
+        <span className="absolute inset-0 flex flex-col items-center justify-center">
+          <span className="text-xl font-semibold tabular-nums text-sos-strong">
+            {value}/{max}
+          </span>
+          <span className="text-xs tabular-nums text-emerald-200">{pct}%</span>
+        </span>
+      </div>
+      <span className="text-[13px] font-medium text-sos-muted">{label}</span>
+    </div>
+  )
+}

--- a/apps/frontend/src/features/stats/components/charts/RadialGauge.tsx
+++ b/apps/frontend/src/features/stats/components/charts/RadialGauge.tsx
@@ -1,0 +1,59 @@
+type RadialGaugeProps = {
+  /** 0–100 사이 진행 값. 범위를 벗어나면 clamp 된다. */
+  value: number
+  /** 게이지 중앙에 크게 표시할 텍스트 (예: "83%"). */
+  valueText: string
+  /** 게이지 아래 라벨 (예: "완주율"). */
+  label: string
+}
+
+const SIZE = 104
+const STROKE = 10
+const RADIUS = (SIZE - STROKE) / 2
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS
+
+/** 완주율 등 0–100% 지표용 원형 게이지(손수 SVG, 의존성 없음). */
+export function RadialGauge({ value, valueText, label }: RadialGaugeProps) {
+  const pct = Math.max(0, Math.min(100, value))
+  const dash = (pct / 100) * CIRCUMFERENCE
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <div className="relative" style={{ width: SIZE, height: SIZE }}>
+        <svg
+          viewBox={`0 0 ${SIZE} ${SIZE}`}
+          width={SIZE}
+          height={SIZE}
+          role="img"
+          aria-label={`${label} ${valueText}`}
+        >
+          <circle
+            cx={SIZE / 2}
+            cy={SIZE / 2}
+            r={RADIUS}
+            fill="none"
+            strokeWidth={STROKE}
+            className="text-slate-800"
+            stroke="currentColor"
+          />
+          <circle
+            cx={SIZE / 2}
+            cy={SIZE / 2}
+            r={RADIUS}
+            fill="none"
+            strokeWidth={STROKE}
+            strokeLinecap="round"
+            strokeDasharray={`${dash} ${CIRCUMFERENCE - dash}`}
+            transform={`rotate(-90 ${SIZE / 2} ${SIZE / 2})`}
+            className="text-emerald-400 transition-[stroke-dasharray]"
+            stroke="currentColor"
+          />
+        </svg>
+        <span className="absolute inset-0 flex items-center justify-center text-2xl font-semibold tabular-nums text-sos-strong">
+          {valueText}
+        </span>
+      </div>
+      <span className="text-[13px] font-medium text-sos-muted">{label}</span>
+    </div>
+  )
+}

--- a/apps/frontend/src/features/stats/components/charts/__tests__/charts.test.tsx
+++ b/apps/frontend/src/features/stats/components/charts/__tests__/charts.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import { DonutChart } from '../DonutChart'
+import { RadialGauge } from '../RadialGauge'
+
+describe('RadialGauge', () => {
+  it('renders the value text, label, and an accessible label', () => {
+    render(<RadialGauge value={83} valueText="83%" label="완주율" />)
+
+    expect(screen.getByText('83%')).toBeInTheDocument()
+    expect(screen.getByText('완주율')).toBeInTheDocument()
+    expect(screen.getByRole('img', { name: '완주율 83%' })).toBeInTheDocument()
+  })
+})
+
+describe('DonutChart', () => {
+  it('renders N/M, the computed percent, and an accessible label', () => {
+    render(<DonutChart value={5} max={60} label="결말 수집" />)
+
+    expect(screen.getByText('5/60')).toBeInTheDocument()
+    // round(5/60*100) = 8
+    expect(screen.getByText('8%')).toBeInTheDocument()
+    expect(screen.getByRole('img', { name: '결말 수집 5/60 (8%)' })).toBeInTheDocument()
+  })
+
+  it('renders 0% without dividing by zero when max is 0', () => {
+    render(<DonutChart value={0} max={0} label="결말 수집" />)
+
+    expect(screen.getByText('0/0')).toBeInTheDocument()
+    expect(screen.getByText('0%')).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/features/stats/hooks.ts
+++ b/apps/frontend/src/features/stats/hooks.ts
@@ -14,3 +14,13 @@ export const useUserStats = () => {
     enabled: Boolean(accessToken),
   })
 }
+
+export const usePhishingBreakdown = () => {
+  const accessToken = useAuthStore((state) => state.accessToken)
+
+  return useQuery({
+    queryKey: statsKeys.phishingBreakdown(),
+    queryFn: statsApi.getPhishingBreakdown,
+    enabled: Boolean(accessToken),
+  })
+}

--- a/apps/frontend/src/features/stats/queryKeys.ts
+++ b/apps/frontend/src/features/stats/queryKeys.ts
@@ -1,4 +1,5 @@
 export const statsKeys = {
   all: ['stats'] as const,
   me: () => [...statsKeys.all, 'me'] as const,
+  phishingBreakdown: () => [...statsKeys.all, 'phishing-breakdown'] as const,
 }

--- a/apps/frontend/src/features/stats/types.ts
+++ b/apps/frontend/src/features/stats/types.ts
@@ -9,3 +9,12 @@ export type UserStat = {
   avgScore: number
   bestScore: number
 }
+
+// 백엔드 PhishingBreakdownResponse 도 camelCase. safeRate 는 프론트 파생.
+export type PhishingBreakdown = {
+  phishingType: string
+  playCount: number
+  goodCount: number
+  avgDangerous: number
+  avgScore: number
+}

--- a/apps/game-engine/app/api/routes/internal.py
+++ b/apps/game-engine/app/api/routes/internal.py
@@ -13,6 +13,7 @@ from app.models.scenario import Scenario
 from app.models.user_scenario_progress import UserScenarioProgress
 from app.schemas.game import (
     EndingCategoryView,
+    PhishingBreakdownResponse,
     PlayLogDetailResponse,
     PlayLogSummaryResponse,
     ScenarioProgressResponse,
@@ -75,6 +76,42 @@ async def list_user_play_logs(
             dangerous_count=r.dangerous_count,
             duration_seconds=r.duration_seconds,
             completed_at=r.completed_at,
+        )
+        for r in rows
+    ]
+
+
+@router.get(
+    "/stats/phishing-breakdown/{user_id}",
+    response_model=list[PhishingBreakdownResponse],
+    summary="유저 사기 유형별 강약점 집계 (internal)",
+)
+async def get_phishing_breakdown(user_id: int) -> list[PhishingBreakdownResponse]:
+    # play_logs(완료 기록만 존재)를 phishing_type 으로 그룹. 미플레이 → 빈 목록.
+    # play_count desc 정렬, 동률은 phishing_type asc 로 결정적 순서.
+    pipeline = [
+        {"$match": {"user_id": user_id}},
+        {
+            "$group": {
+                "_id": "$phishing_type",
+                "play_count": {"$sum": 1},
+                "good_count": {
+                    "$sum": {"$cond": [{"$eq": ["$ending_type", "ending_good"]}, 1, 0]}
+                },
+                "avg_dangerous": {"$avg": "$dangerous_count"},
+                "avg_score": {"$avg": "$total_score"},
+            }
+        },
+        {"$sort": {"play_count": -1, "_id": 1}},
+    ]
+    rows = await PlayLog.aggregate(pipeline).to_list()
+    return [
+        PhishingBreakdownResponse(
+            phishing_type=r["_id"],
+            play_count=r["play_count"],
+            good_count=r["good_count"],
+            avg_dangerous=round(r["avg_dangerous"], 2),
+            avg_score=round(r["avg_score"], 2),
         )
         for r in rows
     ]

--- a/apps/game-engine/app/api/routes/scenarios.py
+++ b/apps/game-engine/app/api/routes/scenarios.py
@@ -45,6 +45,7 @@ async def list_scenarios(
             total_endings=s.total_endings,
             total_good_endings=s.total_good_endings,
             total_bad_endings=s.total_bad_endings,
+            total_categories=len(s.ending_categories or {}),
             tags=s.tags,
         )
         for s in scenarios

--- a/apps/game-engine/app/core/backend_client.py
+++ b/apps/game-engine/app/core/backend_client.py
@@ -6,8 +6,8 @@ best-effort: 실패해도 게임 완료는 항상 성공해야 하므로 모든 
 
 결말 도달 시 새로 달성한 업적 목록을 응답(ApiResponse<GameCompletedResponse>)에서
 파싱해 호출자(move 핸들러)가 MoveResponse 로 클라이언트에 전달한다. 호출자는 이 결과를
-await 하므로 backend 가 느리면 결말 응답이 지연될 수 있으나, 타임아웃(2s/3s) + 예외 흡수로
-게임 완료 자체는 항상 성공한다.
+await 하므로 backend 가 느리면 결말 응답이 지연될 수 있으나, 타임아웃(connect 2s/read 1.5s) +
+예외 흡수로 게임 완료 자체는 항상 성공한다.
 """
 from __future__ import annotations
 
@@ -22,7 +22,9 @@ from app.schemas.game import UnlockedAchievementView
 logger = logging.getLogger(__name__)
 
 _ENDPOINT = "/api/internal/stats/game-completed"
-_TIMEOUT = httpx.Timeout(connect=2.0, read=3.0, write=3.0, pool=3.0)
+# read 를 1.5s 로 단축: 이 호출이 /move 응답(=엔딩 화면)을 블록하므로, backend 지연 시
+# 사용자가 엔딩을 보기까지의 최악 대기를 줄인다. 실패 시 [] 반환(best-effort)이라 안전.
+_TIMEOUT = httpx.Timeout(connect=2.0, read=1.5, write=3.0, pool=3.0)
 
 
 class GameCompletedPayload(BaseModel):

--- a/apps/game-engine/app/schemas/game.py
+++ b/apps/game-engine/app/schemas/game.py
@@ -31,6 +31,7 @@ class ScenarioSummary(BaseModel):
     total_endings: int
     total_good_endings: int
     total_bad_endings: int
+    total_categories: int  # 결말 유형(ending_category) 수 = len(ending_categories). 미분류 시 0.
     tags: list[str]
 
 
@@ -133,7 +134,7 @@ class ScenarioProgressResponse(BaseModel):
 
 class PlayLogSummaryResponse(BaseModel):
     """internal: GET /api/internal/play-logs/user/{user_id}?scenario_id={id} 응답
-    
+
     전부 play_log denorm — 시나리오 join 불필요. completed_at desc 정렬은 라우트 책임.
     """
 
@@ -163,3 +164,16 @@ class PlayLogDetailResponse(BaseModel):
     image_url: str | None = None
     text: str
     ending_category: EndingCategoryView | None = None
+
+
+class PhishingBreakdownResponse(BaseModel):
+    """internal: GET /api/internal/stats/phishing-breakdown/{user_id} 응답 항목.
+
+    play_logs 를 phishing_type 으로 그룹한 유형별 강약점 집계.
+    """
+
+    phishing_type: str
+    play_count: int
+    good_count: int  # ending_good 도달 수 (safe_rate = good_count / play_count)
+    avg_dangerous: float
+    avg_score: float

--- a/apps/game-engine/tests/test_backend_client.py
+++ b/apps/game-engine/tests/test_backend_client.py
@@ -8,8 +8,14 @@ import json
 
 import httpx
 
-from app.core.backend_client import GameCompletedPayload, notify_game_completed
+from app.core.backend_client import _TIMEOUT, GameCompletedPayload, notify_game_completed
 from app.core.config import settings
+
+
+def test_read_timeout_is_shortened_to_avoid_blocking_ending():
+    # 이 호출이 /move 응답(엔딩 화면)을 블록하므로 read 타임아웃을 1.5s 로 제한한다.
+    assert _TIMEOUT.read == 1.5
+    assert _TIMEOUT.connect == 2.0
 
 
 def _payload() -> GameCompletedPayload:

--- a/apps/game-engine/tests/test_internal_phishing_breakdown.py
+++ b/apps/game-engine/tests/test_internal_phishing_breakdown.py
@@ -1,0 +1,101 @@
+"""internal /stats/phishing-breakdown 엔드포인트 — 유저 사기 유형별 강약점 집계.
+
+auth(X-Internal-Api-Key)는 test_internal_auth.py 가 책임 → 여기선 verify_internal_api_key 를
+override 하고 집계 계약(그룹/good_count/avg/정렬/빈목록)만 검증한다.
+internal 라우터는 conftest 의 app_for_routes 에 없어 전용 app·client fixture 를 둔다.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+
+from app.api.routes import internal as internal_routes
+from app.core.internal_auth import verify_internal_api_key
+from app.models.common import Resources
+from app.models.play_log import PlayLog
+
+
+@pytest.fixture
+def internal_app(test_db) -> FastAPI:
+    app = FastAPI()
+    app.include_router(internal_routes.router, prefix="/api/internal")
+    app.dependency_overrides[verify_internal_api_key] = lambda: None
+    return app
+
+
+@pytest_asyncio.fixture
+async def internal_client(internal_app: FastAPI):
+    transport = httpx.ASGITransport(app=internal_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    internal_app.dependency_overrides.clear()
+
+
+async def _seed_play_log(
+    *,
+    log_id: str,
+    user_id: int,
+    phishing_type: str,
+    ending_type: str,
+    dangerous_count: int,
+    total_score: int,
+) -> None:
+    await PlayLog(
+        log_id=log_id,
+        scenario_id="sc1",
+        user_id=user_id,
+        path=[0],
+        final_node_id="end",
+        ending_type=ending_type,
+        final_resource=Resources(trust=1, money=2, awareness=3),
+        total_score=total_score,
+        dangerous_count=dangerous_count,
+        total_choices=3,
+        phishing_type=phishing_type,
+        duration_seconds=120,
+        completed_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+    ).insert()
+
+
+async def test_groups_by_phishing_type_with_safe_and_danger_aggregates(
+    internal_client, test_db
+):
+    # smishing: 2판(good 1, bad 1), danger [0,4] avg2, score [80,40] avg60
+    await _seed_play_log(log_id="l1", user_id=7, phishing_type="smishing",
+                         ending_type="ending_good", dangerous_count=0, total_score=80)
+    await _seed_play_log(log_id="l2", user_id=7, phishing_type="smishing",
+                         ending_type="ending_bad", dangerous_count=4, total_score=40)
+    # voice_phishing: 1판(bad), danger 3, score 30
+    await _seed_play_log(log_id="l3", user_id=7, phishing_type="voice_phishing",
+                         ending_type="ending_bad", dangerous_count=3, total_score=30)
+    # 타 유저 기록은 집계에서 제외돼야 함
+    await _seed_play_log(log_id="l4", user_id=99, phishing_type="smishing",
+                         ending_type="ending_good", dangerous_count=0, total_score=99)
+
+    res = await internal_client.get("/api/internal/stats/phishing-breakdown/7")
+    assert res.status_code == 200
+    body = res.json()
+
+    # play_count desc → smishing(2) 먼저, voice_phishing(1) 다음
+    assert [b["phishing_type"] for b in body] == ["smishing", "voice_phishing"]
+
+    smishing = body[0]
+    assert smishing["play_count"] == 2
+    assert smishing["good_count"] == 1
+    assert smishing["avg_dangerous"] == 2.0
+    assert smishing["avg_score"] == 60.0
+
+    voice = body[1]
+    assert voice["play_count"] == 1
+    assert voice["good_count"] == 0
+    assert voice["avg_dangerous"] == 3.0
+
+
+async def test_empty_returns_200_empty_list(internal_client, test_db):
+    res = await internal_client.get("/api/internal/stats/phishing-breakdown/404")
+    assert res.status_code == 200
+    assert res.json() == []

--- a/apps/game-engine/tests/test_scenarios.py
+++ b/apps/game-engine/tests/test_scenarios.py
@@ -58,8 +58,11 @@ async def test_list_scenarios_returns_summaries(client: httpx.AsyncClient):
         "total_endings",
         "total_good_endings",
         "total_bad_endings",
+        "total_categories",
         "tags",
     }
+    # ending_categories 미설정 시나리오 → 0
+    assert body[0]["total_categories"] == 0
     # nodes 포함 안 됨
     assert "nodes" not in body[0]
 


### PR DESCRIPTION
## 관련 이슈
Closes #78

## 작업 내용
마이페이지·로비·게임 플로우 전반의 UX 보강
알림 실시간성·업적 진행률·엔딩 즉시성 개선, 통계 탭의 자기진단형 대시보드 그래프화, 로비 시나리오 검색

## 변경 사항
- 알림 실시간성 — useNotifications에 60초 폴링(refetchInterval, 백그라운드 폴링 비활성). 벨 뱃지가 수동 invalidate 없이도 준실시간 갱신.
- 업적 진행률 — AchievementResponse에 progress_current/target 노출(서버 단일 소스, 누적형만, target 캡). 업적 카드 하단 N/M 진행 바.
- 엔딩 즉시성 — 게임 완료 동기화(notify_game_completed) read 타임아웃 3s→1.5s 단축으로 엔딩 화면 블록 최소화(best-effort 동작 유지).
- 통계 인사이트 + 그래프화
- 로비 검색 

## 테스트


## 리뷰 포인트
리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 적어주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 업적 카드에 진행률 표시 (누적형 업적의 현재/목표 수치 표시)
  * 로비에서 시나리오 검색 기능 추가
  * 사기 유형별 강약점 분석 기능 추가
  * 통계 대시보드에 완주율 게이지, 시나리오 수집 진행 상황, 피싱 유형별 분석 표시
  * 벨 뱃지 실시간 폴링으로 알림 상태 유지

* **Tests**
  * 업적 진행률 계산 검증 테스트 추가
  * 통계 조회 및 검색 기능 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->