### PR TITLE
[CHORE] 메일 발신주소를 인증된 SendGrid 발신자로 변경 (#92)

### DIFF
--- a/apps/backend/src/main/resources/application.yml
+++ b/apps/backend/src/main/resources/application.yml
@@ -55,6 +55,6 @@ withdrawal:
 
 mail:
   sender:
-    from: noreply@safeorscam.com
+    from: safe.or.scam.skku@gmail.com
     sender-name: Safe or Scam
 


### PR DESCRIPTION
## 관련 이슈
Closes #92 

## 작업 내용
SendGrid **Single Sender Verification**으로 인증한 주소(`safe.or.scam.skku@gmail.com`)로 `mail.sender.from`을 교체한다.

## 변경 사항
- `apps/backend/src/main/resources/application.yml`
  - `mail.sender.from`: `noreply@safeorscam.com` → `safe.or.scam.skku@gmail.com`
  - `sender-name`(Safe or Scam)은 SendGrid From Name과 동일하게 유지

## 테스트
- 발신자 상태 verified 확인
- curl로 API Key 이용해서 SendGrid에 직접 메일 발송 api 쏴서 202 응답 확인
- 받은 편지함 메일 온 거 확인

## 참고
- 발신주소는 비밀값이 아니므로 하드코딩(외부 env 미사용). 향후 staging에서 다른 발신주소가 필요하면 `${MAIL_FROM:...}`로 외부화 가능.
- base yml이라 local/dev에도 적용되나, 해당 환경은 Mailpit이 모든 메일을 수신하므로 영향 없음.
- SMTP 자격증명(`MAIL_HOST/PORT/USERNAME/PASSWORD`)은 코드에 없고, #87 에서 Secret Manager로 주입.
- gmail 발신은 SPF/DKIM 정렬 한계로 스팸 위험이 있어, #88 검증 시 실제 수신 테스트 필요.
  (정식 해결은 커스텀 도메인 + Domain Authentication — 보안 강화 항목)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 이메일 발신자 주소를 업데이트했습니다. 이제부터 시스템에서 발송하는 이메일이 새로운 발신자 주소로 전송됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->