### PR TITLE
[CHORE] Cloud Run 배포용 prod DB·Redis 연결 설정 (#88)

### DIFF
--- a/apps/backend/build.gradle.kts
+++ b/apps/backend/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
 	compileOnly("org.projectlombok:lombok")
 	developmentOnly("org.springframework.boot:spring-boot-devtools")
 	runtimeOnly("org.postgresql:postgresql")
+    implementation("com.google.cloud.sql:postgres-socket-factory:1.21.0")
     implementation("org.flywaydb:flyway-core")
     runtimeOnly("org.flywaydb:flyway-database-postgresql")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")

--- a/apps/backend/src/main/resources/application-prod.yml
+++ b/apps/backend/src/main/resources/application-prod.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:postgresql://${DB_HOST}:5432/${POSTGRES_DB}
+    url: "jdbc:postgresql:///${POSTGRES_DB}?cloudSqlInstance=${CLOUD_SQL_CONNECTION_NAME}&socketFactory=com.google.cloud.sql.postgres.SocketFactory"
     username: ${POSTGRES_USER}
     password: ${POSTGRES_PASSWORD}
     driver-class-name: org.postgresql.Driver

--- a/apps/backend/src/main/resources/application-prod.yml
+++ b/apps/backend/src/main/resources/application-prod.yml
@@ -30,7 +30,7 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
-      password: ${REDIS_PASSWORD}
+      password: ${REDIS_PASSWORD:}
 
 server:
   port: 8080


### PR DESCRIPTION
## 관련 이슈
Refs #88 

## 개요
Cloud Run 배포(#88)를 위한 **backend prod 연결 설정 코드 준비**

## 변경 사항
- **Cloud SQL 연결을 Cloud Run 소켓 팩토리 방식으로 전환**
  - `build.gradle.kts`: `com.google.cloud.sql:postgres-socket-factory:1.21.0` 추가
  - `application-prod.yml`: datasource URL을 소켓 팩토리 형식으로 변경
    (`jdbc:postgresql:///${POSTGRES_DB}?cloudSqlInstance=${CLOUD_SQL_CONNECTION_NAME}&socketFactory=...`)
  - 이유: Cloud Run→Cloud SQL은 사설 IP/VPC 라우팅 대신 내장 소켓 커넥터가 표준·안정적
- **Redis 비밀번호 빈 기본값 처리**
  - `application-prod.yml`: `password: ${REDIS_PASSWORD:}` (빈 기본값)
  - 이유: Memorystore를 AUTH 없이(사설 IP) 운영 → 미설정 시 부팅 실패 방지.
    Spring Data Redis는 빈 비번을 `RedisPassword.none()`으로 처리해 AUTH 미전송 → no-auth Redis 정상 연결.

## 테스트
- [x] `./gradlew build` / 로컬 BackendApplication(local 프로파일) 정상 빌드·기동 (의존성·컴파일 확인)
- [ ] 실제 prod DB(소켓 팩토리) 연결은 **#88 배포 시 Cloud Run에서 검증** (로컬 불가)

## 후속 (이 PR 외, #88에서)
- 이미지 Artifact Registry 푸시 → Cloud Run 3개 배포
- env/시크릿 매핑(`--set-secrets`, `--add-cloudsql-instances`, `CLOUD_SQL_CONNECTION_NAME`)
- 실행 SA에 `roles/cloudsql.client` 부여, 서비스 간 URL 연결


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 백엔드 데이터베이스 연결 설정을 개선하여 더욱 안정적인 인프라 구성으로 업데이트했습니다.
  * Redis 설정의 유연성을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->