### PR TITLE
[Fix] 게임엔진 CORS 허용 origin 환경변수화

### DIFF
--- a/apps/game-engine/.env.example
+++ b/apps/game-engine/.env.example
@@ -15,3 +15,5 @@ JWT_SECRET=local-jwt-secret-key-at-least-32-bytes-123
 
 # game-completed 발신 대상 backend base-url. 로컬은 backend 호스트 포트(8080). 배포 시 override.
 BACKEND_BASE_URL=http://localhost:8080
+
+CORS_ALLOWED_ORIGINS=http://localhost:5173

--- a/apps/game-engine/app/core/config.py
+++ b/apps/game-engine/app/core/config.py
@@ -26,17 +26,25 @@ class Settings(BaseSettings):
     jwt_secret: str = (
         "ci-smoke-default-secret-please-override-min-32-bytes-long-string"
     )
-    
+
     # Internal API Key — backend ↔ game-engine 서비스 간 인증.
     # backend 와 동일 키 공유 (infra/.env). default 는 CI import smoke 통과용 —
     # 운영/dev 는 반드시 INTERNAL_API_KEY 환경변수로 override.
     internal_api_key: str = (
         "local-internal-api-key-at-least-16-bytes"
     )
-    
+
     # game-engine >> backend 발신(POST /api/internal/stats/game-completed) 대상 base-url.
     # 로컬은 backend 가 호스트 8080 에서 구동. 운영/배포는 BACKEND_BASE_URL 환경변수로 override.
     backend_base_url: str = "http://localhost:8080"
+
+    # CORS 허용 origin. default 는 로컬 Vite. 운영/배포는 CORS_ALLOWED_ORIGINS 환경변수로 override
+    cors_allowed_origins: str = "http://localhost:5173"
+    cors_allow_origin_regex: str | None = None
+
+    @property
+    def cors_allowed_origins_list(self) -> list[str]:
+        return [o.strip() for o in self.cors_allowed_origins.split(",") if o.strip()]
 
 
 settings = Settings()  # type: ignore[call-arg]

--- a/apps/game-engine/app/main.py
+++ b/apps/game-engine/app/main.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.routes import game_sessions, scenarios, internal
+from app.core.config import settings
 from app.db.mongo import close_mongo, init_mongo, ping
 
 
@@ -21,11 +22,11 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-# game-engine-api v2 §1 + phase3-cross-boundary §5: 개발 환경 frontend (Vite) 허용.
-# 운영 도메인은 system-architect Phase 6 에서 추가.
+# CORS 허용 origin 은 환경변수로 주입(CORS_ALLOWED_ORIGINS)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173"],
+    allow_origins=settings.cors_allowed_origins_list,
+    allow_origin_regex=settings.cors_allow_origin_regex,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## 관련 이슈
Closes #97 

## 작업 내용
- CORS preflight 400 → 시나리오 목록 안 뜸
  - 프로덕션에서 GET /api/v1/scenarios preflight가 게임엔진에서 400(Disallowed CORS origin)으로 거부됨

## 변경 사항
- config.py
- main.py
- .env.example
- 기본값은 로컬 Vite(http://localhost:5173) 유지
- Cloud Run 게임엔진 env에 CORS_ALLOWED_ORIGINS=http://localhost:5173,https://safe-or-scam.vercel.app 설정 후 재배포 필요.


## 스크린샷
UI 변경이 있다면 첨부해주세요.
<img width="1145" height="871" alt="image" src="https://github.com/user-attachments/assets/36615bb1-7021-4d92-9388-2783deff27b0" />
