### PR TITLE
[Fix] Vercel SPA fallback rewrite 추가

### DIFF
--- a/apps/frontend/vercel.json
+++ b/apps/frontend/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
## 관련 이슈
Closes #99

## 작업 내용
BrowserRouter 기반 SPA라 클라이언트 라우트를 새로고침, 직접 진입하면 Vercel이 해당 파일을 못 찾아 404가 발생

## 변경 사항
- 모든 경로를 index.html로 넘기는 catch-all rewrite를 추가해 딥링크/새로고침에서도 정상 동작하게 파일 추가
- apps/frontend/vercel.json 추가

## 리뷰 포인트
- API는 절대 URL(백엔드/게임엔진)로 호출하므로 이 rewrite와 충돌 없음