### PR TITLE
[CHORE] Cloud Run 자동 배포(CD) 워크플로우 추가 (#90)

### DIFF
--- a/.github/workflows/cd-ai-pipeline.yml
+++ b/.github/workflows/cd-ai-pipeline.yml
@@ -8,12 +8,18 @@ on:
       - '.github/workflows/cd-ai-pipeline.yml'
   workflow_dispatch:   # Actions 탭에서 수동 실행(첫 검증용)
 
+concurrency:
+  group: cd-ai-pipeline-main        
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2

--- a/.github/workflows/cd-ai-pipeline.yml
+++ b/.github/workflows/cd-ai-pipeline.yml
@@ -1,0 +1,38 @@
+name: CD - AI Pipeline
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/ai-pipeline/**'
+      - '.github/workflows/cd-ai-pipeline.yml'
+  workflow_dispatch:   # Actions 탭에서 수동 실행(첫 검증용)
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker asia-northeast3-docker.pkg.dev --quiet
+
+      - name: Build & push image
+        run: |
+          IMAGE=asia-northeast3-docker.pkg.dev/safe-or-scam/sos/ai-pipeline:${{ github.sha }}
+          docker build -t "$IMAGE" apps/ai-pipeline
+          docker push "$IMAGE"
+          echo "IMAGE=$IMAGE" >> "$GITHUB_ENV"
+
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run deploy ai-pipeline --image="$IMAGE" --region=asia-northeast3

--- a/.github/workflows/cd-backend.yml
+++ b/.github/workflows/cd-backend.yml
@@ -1,0 +1,38 @@
+name: CD - Backend
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/backend/**'
+      - '.github/workflows/cd-backend.yml'
+  workflow_dispatch:   # Actions 탭에서 수동 실행(첫 검증용)
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker asia-northeast3-docker.pkg.dev --quiet
+
+      - name: Build & push image
+        run: |
+          IMAGE=asia-northeast3-docker.pkg.dev/safe-or-scam/sos/backend:${{ github.sha }}
+          docker build -t "$IMAGE" apps/backend
+          docker push "$IMAGE"
+          echo "IMAGE=$IMAGE" >> "$GITHUB_ENV"
+
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run deploy backend --image="$IMAGE" --region=asia-northeast3

--- a/.github/workflows/cd-backend.yml
+++ b/.github/workflows/cd-backend.yml
@@ -8,12 +8,18 @@ on:
       - '.github/workflows/cd-backend.yml'
   workflow_dispatch:   # Actions 탭에서 수동 실행(첫 검증용)
 
+concurrency:
+  group: cd-backend-main        
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2

--- a/.github/workflows/cd-game-engine.yml
+++ b/.github/workflows/cd-game-engine.yml
@@ -8,12 +8,18 @@ on:
       - '.github/workflows/cd-game-engine.yml'
   workflow_dispatch:   # Actions 탭에서 수동 실행(첫 검증용)
 
+concurrency:
+  group: cd-game-engine-main        
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2

--- a/.github/workflows/cd-game-engine.yml
+++ b/.github/workflows/cd-game-engine.yml
@@ -1,0 +1,38 @@
+name: CD - Game Engine
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/game-engine/**'
+      - '.github/workflows/cd-game-engine.yml'
+  workflow_dispatch:   # Actions 탭에서 수동 실행(첫 검증용)
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker asia-northeast3-docker.pkg.dev --quiet
+
+      - name: Build & push image
+        run: |
+          IMAGE=asia-northeast3-docker.pkg.dev/safe-or-scam/sos/game-engine:${{ github.sha }}
+          docker build -t "$IMAGE" apps/game-engine
+          docker push "$IMAGE"
+          echo "IMAGE=$IMAGE" >> "$GITHUB_ENV"
+
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run deploy game-engine --image="$IMAGE" --region=asia-northeast3


### PR DESCRIPTION
## 관련 이슈
Refs #90 

## 개요
main 머지 시 변경된 서비스를 자동으로 빌드·푸시·배포하는 CD 파이프라인 추가.
(기존 ci-*.yml은 build/test 게이트로 유지, CD는 별도 워크플로)

## 변경 사항
- `.github/workflows/cd-backend.yml`, `cd-game-engine.yml`, `cd-ai-pipeline.yml` 추가
- 트리거: `push` → `main` + 해당 서비스 경로 변경 시 (+ `workflow_dispatch` 수동 실행)
- 동작: amd64 빌드 → Artifact Registry 푸시(`:${{ github.sha }}` 태그) → `gcloud run deploy --image`
- 배포는 이미지만 교체 → 기존 env·시크릿·Cloud SQL·VPC 설정 보존
- 인증: 서비스계정 키(`secrets.GCP_SA_KEY`)
- frontend는 Vercel 자체 배포라 제외

## 검증 계획
- [ ] 머지 후 Actions 탭에서 `workflow_dispatch`로 1개 수동 실행 → 빌드·배포 성공 확인
- [ ] 이후 develop → main 머지 시 변경 서비스 자동 배포 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 자동화된 배포 파이프라인 추가: AI 파이프라인, 백엔드, 게임 엔진 애플리케이션이 메인 브랜치 업데이트 시 자동으로 빌드되고 배포됩니다. 각 파이프라인은 컨테이너 이미지 생성 후 클라우드 서비스에 배포하며, 수동 배포도 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->