### PR TITLE
[FIX] ai-pipeline non root 컨테이너 data 디렉터리 생성 권한 부여 (#102)

### DIFF
--- a/apps/ai-pipeline/Dockerfile
+++ b/apps/ai-pipeline/Dockerfile
@@ -15,7 +15,10 @@ COPY app ./app
 RUN uv sync --frozen --no-dev
 
 # non-root 사용자로 실행 (Cloud Run 보안 모범사례)
-RUN groupadd --system app && useradd --system --gid app app
+# data 디렉터리를 app 소유로 (앱이 news_cache·images 등을 쓸 수 있게)
+RUN groupadd --system app && useradd --system --gid app app \
+ && mkdir -p /app/app/data \
+ && chown -R app:app /app/app/data
 USER app
 
 EXPOSE 8001


### PR DESCRIPTION
## 관련 이슈
Closes #102 

## 변경
`apps/ai-pipeline/Dockerfile`: `/app/app/data`를 app 유저 소유로 chown
→ non-root 유지하며 news_cache·images 쓰기 가능, CD 부팅 실패 해결.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **작업**
  * AI 파이프라인 컨테이너의 데이터 저장소 디렉터리 초기화 및 파일 소유권 설정을 개선했습니다.
  * 컨테이너 빌드 프로세스에서 필요한 시스템 디렉터리 구조가 올바르게 생성되도록 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->